### PR TITLE
Add project name to docker-compose run commands

### DIFF
--- a/.vim/run
+++ b/.vim/run
@@ -1,35 +1,35 @@
 #!/usr/bin/env sh
 
 [ "start" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml up --detach && \
-  docker-compose --file .devcontainer/docker-compose.yaml exec alvtime-vue-dev npx vue-cli-service serve
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa up --detach && \
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa exec alvtime-vue-dev npx vue-cli-service serve
 
 [ "up" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml up --detach
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa up --detach
 
 [ "serve" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml exec alvtime-vue-dev npx vue-cli-service serve
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa exec alvtime-vue-dev npx vue-cli-service serve
 
 [ "down" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml down --volumes
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa down --volumes
 
 [ "logs" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml logs --follow
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa logs --follow
 
 [ "pull" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml pull
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa pull
 
 [ "build" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml build
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa build
 
 [ "test" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml exec alvtime-vue-dev npx vue-cli-service test:unit
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa exec alvtime-vue-dev npx vue-cli-service test:unit
 
 [ "test:e2e" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml exec alvtime-vue-dev npx vue-cli-service test:e2e
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa exec alvtime-vue-dev npx vue-cli-service test:e2e
 
 [ "lint" = $1 ] && \
-  docker-compose --file .devcontainer/docker-compose.yaml exec alvtime-vue-dev npx vue-cli-service lint run lint
+  docker-compose --file .devcontainer/docker-compose.yaml --project-name alvtime-vue-pwa exec alvtime-vue-dev npx vue-cli-service lint run lint
 
 [ "local-up" = $1 ] && \
   docker-compose up --build


### PR DESCRIPTION
This was done to give different names to the nginx image built by
alvtime-vue-pwa and alvtime-admin-react-pwa. Without this the
devcontainer would use the one that was built last. This crashed the
nginx server when the build was done in the other project.