### PR TITLE
Added endpoint for red days

### DIFF
--- a/packages/api/AlvTimeWebApi/Controllers/HolidayController.cs
+++ b/packages/api/AlvTimeWebApi/Controllers/HolidayController.cs
@@ -1,0 +1,28 @@
+﻿using AlvTime.Business;
+using AlvTimeWebApi.Controllers.Utils;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+
+namespace AlvTimeWebApi.Controllers
+{
+    [Route("api")]
+    [ApiController]
+    public class HolidayController : Controller
+    {
+        [HttpGet("Holidays")]
+        [Authorize]
+        public ActionResult<IEnumerable<string>> FetchRedDays([FromQuery] int year)
+        {
+            var redDays = new RedDays(year);
+            var dates = new List<string>();
+
+            foreach (var date in redDays.Dates)
+            {
+                dates.Add(date.ToDateOnly());
+            }
+
+            return Ok(dates);
+        }
+    }
+}

--- a/packages/api/Tests/UnitTests/Flexihours/CancelPayoutTests.cs
+++ b/packages/api/Tests/UnitTests/Flexihours/CancelPayoutTests.cs
@@ -3,9 +3,7 @@ using AlvTime.Business.Options;
 using AlvTime.Persistence.DataBaseModels;
 using AlvTime.Persistence.Repositories;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Xunit;
 using static Tests.UnitTests.Flexihours.GetOvertimeTests;
 
@@ -22,8 +20,9 @@ namespace Tests.UnitTests.Flexihours
             dbUser.StartDate = new DateTime(2020, 11, 01);
 
             var currentMonth = DateTime.Now.Month;
+            var currentYear = DateTime.Now.Year;
 
-            _context.Hours.Add(CreateTimeEntry(date: new DateTime(2020, currentMonth, 02), value: 17.5M, out int taskid));
+            _context.Hours.Add(CreateTimeEntry(date: new DateTime(currentYear, currentMonth, 02), value: 17.5M, out int taskid));
             _context.CompensationRate.Add(CreateCompensationRate(taskid, 1.0M));
 
             _context.SaveChanges();
@@ -32,7 +31,7 @@ namespace Tests.UnitTests.Flexihours
 
             var registerOvertimeResponse = calculator.RegisterPaidOvertime(new GenericHourEntry
             {
-                Date = new DateTime(2020, currentMonth, 02),
+                Date = new DateTime(currentYear, currentMonth, 02),
                 Hours = 10
             }, 1).Value as PaidOvertime;
 


### PR DESCRIPTION
Endpunkt tar inn år fra query og returnerer en liste med datoer som strenger. Inkluderer alle helligdager og Alv-dager. Hellidager rapporteres selv om de faller på en lørdag eller søndag.