### PR TITLE
Changed dotnet version from .NET Core 3.1 -> .NET 5.0 in devcontainer

### DIFF
--- a/packages/api/.devcontainer/Dockerfile
+++ b/packages/api/.devcontainer/Dockerfile
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-ARG VARIANT="3.1-bionic"
-FROM mcr.microsoft.com/dotnet/core/sdk:${VARIANT}
+ARG VARIANT="5.0"
+FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs


### PR DESCRIPTION
Was not able to build the API from the previous dev container, as the API was .NET 5.0 and the SDK was .NET Core 3.1. With the changes, it is possible to build and test the project from the dev container with `dotnet build` and `dotnet watch test`