### PR TITLE
embed admin panel as a microfrontend script

### DIFF
--- a/packages/adminpanel/src/components/AzureAdAuthenticator.tsx
+++ b/packages/adminpanel/src/components/AzureAdAuthenticator.tsx
@@ -107,9 +107,9 @@ async function isAdmin(account: AccountInfo | null) {
   if (!account) return false;
   const path = "/api/admin/Tasks";
   const adAuthenticatedFetch = createAdAuthenticatedFetch(account);
-  const res = await adAuthenticatedFetch(
-    config.API_HOST + path
-  ).catch((error) => console.error(error.message));
+  const res = await adAuthenticatedFetch(config.API_HOST + path).catch(
+    (error) => console.error(error.message)
+  );
   return res && res.ok;
 }
 

--- a/packages/frontend/public/index.html
+++ b/packages/frontend/public/index.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -19,6 +18,10 @@
       >
     </noscript>
     <div id="app"></div>
+    <div id="root"></div>
+    <script src="http://localhost:3000/static/js/bundle.js"></script>
+    <script src="http://localhost:3000/static/js/0.chunk.js"></script>
+    <script src="http://localhost:3000/static/js/main.chunk.js"></script>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/packages/frontend/src/components/Drawer.vue
+++ b/packages/frontend/src/components/Drawer.vue
@@ -27,10 +27,6 @@
           >{{ item.text }}</span
         >
       </md-list-item>
-      <md-list-item @click="navToAdminpanel">
-        <md-icon>admin_panel_settings</md-icon>
-        <span class="md-list-item-text">Adminpanel</span>
-      </md-list-item>
       <md-list-item @click="authAction">
         <md-icon>meeting_room</md-icon>
         <span class="md-list-item-text">{{ authText }}</span>
@@ -72,6 +68,11 @@ export default Vue.extend({
           routeName: "tokens",
           icon: "lock_open",
         },
+        {
+          text: "Admin Panel",
+          routeName: "admin",
+          icon: "admin_panel_settings"
+        }
       ],
     };
   },

--- a/packages/frontend/src/router/index.ts
+++ b/packages/frontend/src/router/index.ts
@@ -10,6 +10,7 @@ import Login from "../views/Login.vue";
 import Summarizedhours from "../views/Summarizedhours.vue";
 import store from "@/store";
 import authService from "@/services/auth";
+import Admin from '../views/Admin.vue'
 
 Vue.use(VueRouter);
 
@@ -54,6 +55,11 @@ const routes = [
     path: "/summarizedhours",
     name: "summarizedhours",
     component: Summarizedhours,
+  },
+  {
+    path: "/admin",
+    name: "admin",
+    component: Admin
   }
 ];
 

--- a/packages/frontend/src/views/Admin.vue
+++ b/packages/frontend/src/views/Admin.vue
@@ -1,0 +1,38 @@
+<template>
+  <div id="root">
+  </div>
+</template>
+
+<script lang="ts">
+
+import Vue from "vue";
+
+export default Vue.extend({
+  components: {
+  },
+
+  computed: {
+  },
+
+  methods: {
+      insertScripts() {
+        const microScripts = [
+        'http://localhost:3000/static/js/bundle.js', 
+        'http://localhost:3000/static/js/0.chunk.js', 
+        'http://localhost:3000/static/js/main.chunk.js']
+        
+        microScripts.forEach(uri => {
+            const el = document.createElement('script')
+            el.setAttribute('src', uri)
+            document.querySelector('body').appendChild(el)
+            })
+      }
+  },
+  mounted() {
+    this.insertScripts()
+      }
+});
+</script>
+
+<style scoped>
+</style>


### PR DESCRIPTION
Adding the scripts directly to alvtime did show the admin panel without redirecting to the login page.
However, doing it as a lazy load in the vue component redirected a authentication route.