### PR TITLE
Feature/expand truncated texts

### DIFF
--- a/packages/frontend/src/components/FavoriteSelector.vue
+++ b/packages/frontend/src/components/FavoriteSelector.vue
@@ -10,8 +10,8 @@
           @click="clear"
         />
       </div>
-      <div v-for="task in tasks" :key="task.id" class="row">
-        <TimeEntrieText :task="task" />
+      <div v-for="task in tasks" :key="task.id" class="row" >
+        <TimeEntrieText :task="task" :isExpanded="task.id === selectedEntryKey" @expand-entry="onExpandEntry"/>
         <md-checkbox
           :value="!task.favorite"
           type="checkbox"
@@ -43,6 +43,7 @@ export default Vue.extend({
   data() {
     return {
       searchphrase: "",
+      selectedEntryKey: -1
     };
   },
 
@@ -76,6 +77,14 @@ export default Vue.extend({
         { ...task, favorite: !task.favorite },
       ]);
     },
+    onExpandEntry(id: number) {
+      // If selected entry is same as currently selected, reset to close entry
+      if (this.selectedEntryKey === id) {
+        this.selectedEntryKey = -1;
+      } else {
+        this.selectedEntryKey = id;
+      }
+    }
   },
 });
 </script>

--- a/packages/frontend/src/components/TimeEntrieDayList.vue
+++ b/packages/frontend/src/components/TimeEntrieDayList.vue
@@ -3,7 +3,7 @@
     <HolidayPill v-if="holiday" :holiday="holiday" />
     <ZeroSelectedTasks v-if="rows.length < 1" />
     <div v-for="row in rows" :key="row.task.id" class="grid">
-      <TimeEntrieText :task="row.task" />
+      <TimeEntrieText :task="row.task" :isExpanded="row.task.id === selectedEntryKey" @expand-entry="onExpandEntry"/>
       <HourInput :time-entrie="row.timeEntrie" :is-locked="row.task.locked" />
     </div>
   </div>
@@ -40,6 +40,11 @@ export default Vue.extend({
       },
     },
   },
+  data() {
+    return {
+      selectedEntryKey: -1
+    }
+  }, 
   computed: {
     rows(): Row[] {
       return [...this.rowsWithHours, ...this.rowsWithoutHours].sort(sortList);
@@ -111,6 +116,14 @@ export default Vue.extend({
 
       return { task, timeEntrie };
     },
+    onExpandEntry(id: number) {
+      // If selected entry is same as currently selected, reset to close entry
+      if (this.selectedEntryKey === id) {
+        this.selectedEntryKey = -1;
+      } else {
+        this.selectedEntryKey = id;
+      }
+    }
   },
 });
 

--- a/packages/frontend/src/components/TimeEntrieText.vue
+++ b/packages/frontend/src/components/TimeEntrieText.vue
@@ -1,13 +1,31 @@
 <template>
-  <div class="entry-container">
-    <div class="entry-text">
+  <div class="entry-container" @click="$emit('expand-entry', task.id)">
+    <div class="entry-text" v-if="!isExpanded">
       <span class="customer-name truncate-text">{{ task.project.customer.name }} - {{ task.project.name }}</span>  
       <span class="activity-name truncate-text">{{ task.name }}</span>
+    </div>
+    <div class="entry-text-expanded" v-if="isExpanded">
+      <label class="expanded-label">
+        Kunde:
+        <span class="expanded-text">{{ task.project.customer.name }}</span>  
+      </label>
+      <label class="expanded-label">
+        Prosjekt:
+        <span class="expanded-text">{{ task.project.name }}</span>  
+      </label>
+      <label class="expanded-label">
+        Oppgave:
+        <span class="expanded-text">{{ task.name }}</span>
+      </label>
+      <label class="expanded-label">
+        Rate:
+        <small class="expanded-text">{{ compensationRatePercentage }}</small>
+      </label>      
     </div>
     <div v-show="showPadlock" class="padlock-container">
       <md-icon class="padlock-icon">lock</md-icon>
     </div>
-    <div class="rate-container">
+    <div class="rate-container"  v-if="!isExpanded">
         <small class="rate-text">{{ compensationRatePercentage }}</small>
     </div>
   </div>
@@ -25,6 +43,7 @@ export default Vue.extend({
         return {} as Task;
       },
     },
+    isExpanded: Boolean
   },
   computed: {
     compensationRatePercentage(): string {
@@ -32,7 +51,7 @@ export default Vue.extend({
     },
     showPadlock(): boolean {
       return this.task.locked;
-    },
+    }
   },
 });
 </script>
@@ -52,6 +71,24 @@ export default Vue.extend({
   flex-direction: column;
   min-width: 0;
   margin-right: auto;
+}
+
+.entry-text-expanded {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  margin-right: auto; 
+  margin-top: .4rem;
+  margin-bottom: .4rem;
+  word-break: break-word;
+}
+
+.expanded-label {
+  font-weight: 600;
+}
+.expanded-text {
+  font-weight: normal;
+  font-size: 0.8rem;
 }
 
 .customer-name {

--- a/packages/frontend/src/components/TimeEntrieWeekList.vue
+++ b/packages/frontend/src/components/TimeEntrieWeekList.vue
@@ -11,7 +11,11 @@
       </div>
       <ZeroSelectedTasks v-if="tasks.length < 1" />
       <div v-for="task in tasks" :key="task.id" class="row">
-        <TimeEntrieText :task="task" />
+        <TimeEntrieText
+          :task="task"
+          :isExpanded="task.id === selectedEntryKey"
+          @expand-entry="onExpandEntry"
+        />
         <TimeEntrieWeek :task="task" :week="week" />
       </div>
     </div>
@@ -39,7 +43,11 @@ export default Vue.extend({
     ZeroSelectedTasks,
   },
   props: { week: { type: Array as () => Moment[], default: () => [] } },
-
+  data() {
+    return {
+      selectedEntryKey: -1,
+    };
+  },
   computed: {
     tasks(): Task[] {
       const rows = [...this.tasksWithHours, ...this.tasksWithoutHours].sort(
@@ -61,7 +69,7 @@ export default Vue.extend({
       const tasks: Task[] = [];
       for (const entrie of this.weeksTimeEntries) {
         const task = this.$store.getters.getTask(entrie.taskId);
-        if (!tasks.some(t => t.id === task.id)) {
+        if (!tasks.some((t) => t.id === task.id)) {
           tasks.push(task);
         }
       }
@@ -70,7 +78,7 @@ export default Vue.extend({
 
     tasksWithoutHours(): Task[] {
       return this.$store.getters.favoriteTasks.filter(
-        (task: Task) => !this.tasksWithHours.some(t => t.id === task.id)
+        (task: Task) => !this.tasksWithHours.some((t) => t.id === task.id)
       );
     },
 
@@ -103,6 +111,14 @@ export default Vue.extend({
       return this.week.some(
         (date: Moment) => date.format(config.DATE_FORMAT) === d
       );
+    },
+    onExpandEntry(id: number) {
+      // If selected entry is same as currently selected, reset to close entry
+      if (this.selectedEntryKey === id) {
+        this.selectedEntryKey = -1;
+      } else {
+        this.selectedEntryKey = id;
+      }
     },
   },
 });


### PR DESCRIPTION
Når bruker trykker på en rad i listen, åpnes den for utvidet visning. Kun en rad er utvidet av gangen. Trykker man på utvidet rad, lukkes den. [#434]
![Screen Shot 2021-12-13 at 00 10 58](https://user-images.githubusercontent.com/12566124/145733692-6efad6ad-2bc1-443a-9d76-06415c450edb.png)

![Screen Shot 2021-12-13 at 00 11 13](https://user-images.githubusercontent.com/12566124/145733696-06e1b0a5-1ad6-43a6-b929-30dd3a44b3d4.png)

![Screen Shot 2021-12-13 at 00 11 35](https://user-images.githubusercontent.com/12566124/145733698-91a7955f-d037-4b39-9b73-0fc83edb8ecd.png)

![Screen Shot 2021-12-13 at 00 19 30](https://user-images.githubusercontent.com/12566124/145733703-2c284aa7-e81e-4ce1-9155-3aa241ca3346.png)
<img width="1366" alt="Skjermbilde 2021-12-13 kl  00 27 04" src="https://user-images.githubusercontent.com/12566124/145733924-d1a67bbe-bd36-44cf-afa4-e16fab7b7e66.png">

