### PR TITLE
Valid PATs should be rejected if their associated users are expired

### DIFF
--- a/packages/api/AlvTime.Business/Users/IUserStorage.cs
+++ b/packages/api/AlvTime.Business/Users/IUserStorage.cs
@@ -7,7 +7,7 @@ namespace AlvTime.Business.Users
 {
     public interface IUserStorage
     {
-        IEnumerable<UserResponseDto> GetUser(UserQuerySearch criterias);
+        IEnumerable<UserResponseDto> GetUser(UserQuerySearch criteria);
         void AddUser(CreateUserDto user);
         void UpdateUser(CreateUserDto user);
         Task<User> GetUserFromToken(Token token);

--- a/packages/api/AlvTime.Persistence/Repositories/UserStorage.cs
+++ b/packages/api/AlvTime.Persistence/Repositories/UserStorage.cs
@@ -84,7 +84,8 @@ namespace AlvTime.Persistence.Repositories
                 {
                     Id = databaseUser.Id,
                     Email = databaseUser.Email,
-                    Name = databaseUser.Name
+                    Name = databaseUser.Name,
+                    EndDate = databaseUser.EndDate
                 };
             }
 

--- a/packages/api/AlvTime.Persistence/Repositories/UserStorage.cs
+++ b/packages/api/AlvTime.Persistence/Repositories/UserStorage.cs
@@ -34,10 +34,10 @@ namespace AlvTime.Persistence.Repositories
             _context.SaveChanges();
         }
 
-        public IEnumerable<UserResponseDto> GetUser(UserQuerySearch criterias)
+        public IEnumerable<UserResponseDto> GetUser(UserQuerySearch criteria)
         {
             return _context.User.AsQueryable()
-                .Filter(criterias)
+                .Filter(criteria)
                 .Select(u => new UserResponseDto
                 {
                     Email = u.Email,

--- a/packages/api/Tests/UnitTests/AccessToken/AccessTokenStorageTests.cs
+++ b/packages/api/Tests/UnitTests/AccessToken/AccessTokenStorageTests.cs
@@ -1,8 +1,18 @@
-﻿using AlvTime.Persistence.Repositories;
+﻿using System;
 using System.Linq;
-using System;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
 using AlvTime.Business.AccessTokens;
 using AlvTime.Business.Models;
+using AlvTime.Business.Users;
+using AlvTime.Persistence.Repositories;
+using AlvTimeWebApi.Authentication.PersonalAccessToken;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using Moq;
 using Xunit;
 
 namespace Tests.UnitTests.AccessToken
@@ -20,10 +30,10 @@ namespace Tests.UnitTests.AccessToken
 
             var user = new User
             {
-                Name = context.User.First().Name, 
+                Name = context.User.First().Name,
                 Email = context.User.First().Email
             };
-            
+
             var tokens = storage.GetActiveTokens(user);
 
             Assert.Equal(context.AccessTokens.Where(x => x.UserId == 1).ToList().Count(), tokens.Count());
@@ -36,10 +46,10 @@ namespace Tests.UnitTests.AccessToken
                 .WithPersonalAccessTokens()
                 .WithUsers()
                 .CreateDbContext();
-            
+
             var user = new User
             {
-                Name = context.User.First().Name, 
+                Name = context.User.First().Name,
                 Email = context.User.First().Email
             };
 
@@ -67,10 +77,10 @@ namespace Tests.UnitTests.AccessToken
                 .WithPersonalAccessTokens()
                 .WithUsers()
                 .CreateDbContext();
-            
+
             var user = new User
             {
-                Name = context.User.First().Name, 
+                Name = context.User.First().Name,
                 Email = context.User.First().Email
             };
 
@@ -80,6 +90,58 @@ namespace Tests.UnitTests.AccessToken
 
             var tokens = storage.GetActiveTokens(user);
             Assert.Empty(tokens);
+        }
+
+        [Fact]
+        public async Task Authenticate_ExpiredUser_WithValidPAT_ShouldFail()
+        {
+            // Arrange
+            var dbContext = new AlvTimeDbContextBuilder()
+                .WithPersonalAccessTokens()
+                .WithUsers()
+                .CreateDbContext();
+
+            var storage = new UserStorage(dbContext);
+
+            // This user and the following access token are provided by the WithUsers|WithPATs methods above
+            storage.UpdateUser(new CreateUserDto
+            {
+                Id = 1,
+                EndDate = DateTime.Now.AddMonths(-1)
+            });
+
+            var accessToken = await dbContext.AccessTokens.FindAsync(1);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Add(HeaderNames.Authorization, $"Bearer {accessToken?.Value}");
+
+            // The options and loggerFactory objects must return these values. If not, we get a NullPtrException
+            // Source: https://stackoverflow.com/questions/58963133/unit-test-custom-authenticationhandler-middleware
+            var options = new Mock<IOptionsMonitor<PersonalAccessTokenOptions>>();
+            options.Setup(x => x.Get(It.IsAny<string>()))
+                .Returns(new PersonalAccessTokenOptions());
+
+            var logger = new Mock<ILogger<PersonalAccessTokenHandler>>();
+            var loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            var authenticationHandler = new PersonalAccessTokenHandler(
+                options.Object,
+                loggerFactory.Object,
+                UrlEncoder.Default,
+                storage,
+                Mock.Of<SystemClock>());
+
+            await authenticationHandler.InitializeAsync(
+                new AuthenticationScheme(nameof(PersonalAccessTokenHandler), null, typeof(PersonalAccessTokenHandler)),
+                httpContext);
+
+            // Act
+            var result = await authenticationHandler.AuthenticateAsync();
+
+            // Assert
+            Assert.False(result.Succeeded);
+            Assert.Equal("The user has an end date in the past", result.Failure?.Message);
         }
     }
 }


### PR DESCRIPTION
Closes #403 

Before this, only the expiration of the PATs were considered when determining their validity. The users expiration should also be taken into account.