### PR TITLE
Fix alvar error on missing location of details

### DIFF
--- a/packages/slack-app/src/routes/learning-collector/index.ts
+++ b/packages/slack-app/src/routes/learning-collector/index.ts
@@ -93,12 +93,14 @@ boltApp.action(
   }
 );
 
-function sanitizeDescription(description: string) {
+function sanitizeDescription(description?: string | null) {
+  if (!description) return "";
   return description.replace("*", "").replace("\n", " ");
 }
 
-function sanitizeLocationOfDetails(description: string) {
-  return description.replace("*", "");
+function sanitizeLocationOfDetails(locationOfDetails?: string | null) {
+  if (!locationOfDetails) return "";
+  return locationOfDetails.replace("*", "");
 }
 
 function parseViewStateValues(values: {


### PR DESCRIPTION
When the loacation of detail field is omitted the value for it is null.
I dont know why typescript does not give errors for it.