### PR TITLE
Small error making the invoice-rate to High

### DIFF
--- a/packages/api/AlvTimeWebApi/Controllers/InvoiceRateController.cs
+++ b/packages/api/AlvTimeWebApi/Controllers/InvoiceRateController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using AlvTime.Business.InvoiceRate;
-using AlvTimeWebApi.Controllers.Utils;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -33,6 +32,6 @@ public class InvoiceRateController : ControllerBase
             fromDate = DateTime.Now.AddDays(-30);
         }
 
-        return await _invoiceRateService.GetEmployeeInvoiceRateForPeriod(fromDate.Value, toDate.Value);
+        return await _invoiceRateService.GetEmployeeInvoiceRateForPeriod(fromDate.Value.Date, toDate.Value.Date);
     }
 }


### PR DESCRIPTION
Removed time from date, making the calculation correct The invoice date was 5% too high