### PR TITLE
Invoice rate tweak 📦

### DIFF
--- a/packages/api/AlvTimeWebApi/Controllers/InvoiceRateController.cs
+++ b/packages/api/AlvTimeWebApi/Controllers/InvoiceRateController.cs
@@ -29,7 +29,8 @@ public class InvoiceRateController : ControllerBase
 
         if (!fromDate.HasValue)
         {
-            fromDate = DateTime.Now.AddDays(-30);
+            var now = DateTime.Now;
+            fromDate = new DateTime(now.Year, now.Month, 1);
         }
 
         return await _invoiceRateService.GetEmployeeInvoiceRateForPeriod(fromDate.Value.Date, toDate.Value.Date);


### PR DESCRIPTION
The default for the rate-endpoint is to calculate the current month After a poll in the main-channel, we see that the current month is the number most people find useful. No one voted for the initial implementation