### PR TITLE
Changing invoice-rate text

### DIFF
--- a/packages/frontend/src/components/InvoiceRate.vue
+++ b/packages/frontend/src/components/InvoiceRate.vue
@@ -6,6 +6,7 @@
 import { State } from "@/store";
 import Vue from "vue";
 import { Store } from "vuex";
+import { getCurrentMonthName } from "../utils/timestamp-text-util";
 export default Vue.extend({
   props: {
     small: {
@@ -13,15 +14,17 @@ export default Vue.extend({
       default: false,
     },
   },
-  computed: {
-    invoiceRate(): string {
-      return `Fakturering siste 30 d ${this.$store.getters.getInvoiceRate}%`;
-    },
-  },
   data() {
     return {
       unsubscribe: () => {},
     };
+  },
+  computed: {
+    invoiceRate(): string {
+      return `Fakturering ${getCurrentMonthName(true)} ${
+        this.$store.getters.getInvoiceRate
+      }%`;
+    },
   },
   async created() {
     await this.$store.dispatch("FETCH_INVOICE_RATE");
@@ -41,5 +44,4 @@ export default Vue.extend({
   },
 });
 </script>
-<style>
-</style>
+<style></style>

--- a/packages/frontend/src/utils/timestamp-text-util.ts
+++ b/packages/frontend/src/utils/timestamp-text-util.ts
@@ -21,6 +21,17 @@ const months = [
   "Desember",
 ];
 
+export function getCurrentMonthName(lowerCase = false): string {
+  const currentMonthNumber = new Date().getMonth();
+  const month = months[currentMonthNumber];
+
+  if (lowerCase) {
+    return month.toLowerCase();
+  }
+
+  return month;
+}
+
 export function createTimeString(
   year: number,
   month: number,


### PR DESCRIPTION
The text on the top of the screen should reflect the backend change. The string is shorter than the old one. It looks a lot nicer

![image](https://user-images.githubusercontent.com/14232560/214273980-781b2abd-4b1a-4903-a46c-94de4fef39e4.png)
