### PR TITLE
Utbetalinger låses natt til 9. i måneden

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,7 +51,8 @@ services:
     build:
       context: ./packages/api
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - ConnectionStrings__AlvTime_db=Data Source=tcp:db,1433;Initial Catalog=AlvDevDB;User ID=sa;Password=AlvTimeTestErMoro32
       - AzureAd__Domain=api://c9126a83-01c3-43c0-8bb3-298d352d2d7f
@@ -79,6 +80,12 @@ services:
         /opt/mssql/bin/sqlservr &
         # So that the container doesn't shut down, sleep this thread
         sleep infinity
+    healthcheck:
+      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "AlvTimeTestErMoro32" -Q "SELECT 1" -b -o /dev/null
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
 
   slack-app:
     tty: true

--- a/packages/api/AlvTime.Persistence/Repositories/PayoutStorage.cs
+++ b/packages/api/AlvTime.Persistence/Repositories/PayoutStorage.cs
@@ -40,23 +40,24 @@ public class PayoutStorage : IPayoutStorage
             }).ToList()
         };
     }
-
-    private static DateTime FindClosestPreviousCuttoffDate()
-    {
-        var cuttoffDate = DateTime.Now;
-        while (cuttoffDate.Day != 9)
-        {
-            cuttoffDate = cuttoffDate.AddDays(-1);
-        }
-        
-        return new DateTime(year: cuttoffDate.Year, day: cuttoffDate.Day, month: cuttoffDate.Month);
-    }
-
+    
     private static bool IsPayoutActive(PaidOvertime po)
     {
-        var cuttOffDate = FindClosestPreviousCuttoffDate();
-        return po.Date > cuttOffDate;
+        var cutOffDate = FindClosestPreviousCutoffDate();
+        return po.Date > cutOffDate;
     }
+
+    private static DateTime FindClosestPreviousCutoffDate()
+    {
+        var cutoffDate = DateTime.Now;
+        while (cutoffDate.Day != 9)
+        {
+            cutoffDate = cutoffDate.AddDays(-1);
+        }
+        
+        return new DateTime(year: cutoffDate.Year, month: cutoffDate.Month, day: cutoffDate.Day);
+    }
+
 
     public async Task<List<PayoutDto>> RegisterPayout(int userId, GenericPayoutHourEntry request, List<PayoutToRegister> payoutsToRegister)
     {

--- a/packages/api/AlvTime.Persistence/Repositories/PayoutStorage.cs
+++ b/packages/api/AlvTime.Persistence/Repositories/PayoutStorage.cs
@@ -41,30 +41,21 @@ public class PayoutStorage : IPayoutStorage
         };
     }
 
+    private static DateTime FindClosestPreviousCuttoffDate()
+    {
+        var cuttoffDate = DateTime.Now;
+        while (cuttoffDate.Day != 9)
+        {
+            cuttoffDate = cuttoffDate.AddDays(-1);
+        }
+        
+        return new DateTime(year: cuttoffDate.Year, day: cuttoffDate.Day, month: cuttoffDate.Month);
+    }
+
     private static bool IsPayoutActive(PaidOvertime po)
     {
-        //If payout made previous year and current day is more than 8, payout is inactive
-        if (po.Date.Year < DateTime.Now.Year)
-        {
-            return po.Date.Month == 12 && po.Date.Day > 8 && DateTime.Now.DayOfYear <= 8;
-        }
-
-        //If payout is made after the 8th the previous month, or current date is before the 8th the succeeding month, payout is active
-        if (po.Date.Month < DateTime.Now.Month)
-        {
-            if (po.Date.Day <= 8 || DateTime.Now.Day > 8)
-            {
-                return false;
-            }
-
-            if (po.Date.Day > 8 && DateTime.Now.Day <= 8 && DateTime.Now.Month == po.Date.Month + 1)
-            {
-                return true;
-            }
-        }
-
-        //If payout made same month either after the 8th, or current date is before the 8th, payout is active
-        return po.Date.Month == DateTime.Now.Month && (po.Date.Day > 8 || DateTime.Now.Day <= 8);
+        var cuttOffDate = FindClosestPreviousCuttoffDate();
+        return po.Date > cuttOffDate;
     }
 
     public async Task<List<PayoutDto>> RegisterPayout(int userId, GenericPayoutHourEntry request, List<PayoutToRegister> payoutsToRegister)


### PR DESCRIPTION
- Hvis utbetaling er bestilt i fjor før 9. desember - utbetaling låst
- Hvis utbetaling er bestilt i fjor etter 8. desember og dagens dato i år er før 9, januar - utbetaling aktiv
- Hvis utbetaling er bestilt mer enn 1 måned siden (f.eks. bestilt i januar og nå er mars) - utbetaling låst
- Hvis utbetaling er bestilt forrige måned før den 9. - utbetaling låst
- Hvis utbetaling er bestilt forrige måned etter den 8. og dagens dato er før den 9. - utbetaling aktiv
- Hvis utbetaling er bestilt forrige måned etter den 8. og dagens dato er etter den 8. - utbetaling låst
- Hvis utbetaling er bestilt inneværende måned før den 9. og dagens dato er før den 9. - utbetaling aktiv
- Hvis utbetaling er bestilt inneværende måned før den 9. og dagens dato er etter den 8. - utbetaling låst
- Hvis utbetaling er bestilt inneværende måned etter den 8. og dagens dato er etter den 8. - utbetaling aktiv 