### PR TITLE
Add LatestTaskService and related endpoints

### DIFF
--- a/packages/api/AlvTime.Business/Tasks/LatestTaskService.cs
+++ b/packages/api/AlvTime.Business/Tasks/LatestTaskService.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using AlvTime.Business.TimeRegistration;
+using AlvTime.Business.Users;
+
+namespace AlvTime.Business.Tasks
+{
+    public class LatestTaskService
+    {
+        private readonly TaskService _taskService;
+        private readonly TimeRegistrationService _timeRegistrationService;
+
+        public LatestTaskService(TaskService taskService, TimeRegistrationService timeRegistrationService)
+        {
+            _taskService = taskService;
+            _timeRegistrationService = timeRegistrationService;
+        }
+
+        public async Task<IEnumerable<TaskResponseDto>> GetLatestTasksForUser()
+        {
+            var timeEntries = await _timeRegistrationService.GetTimeEntries(new TimeEntryQuerySearch
+            {
+                FromDateInclusive = DateTime.Now.AddDays(-30),
+                ToDateInclusive = DateTime.Now
+            });
+
+            var mostRecentlyUsedTaskIds = timeEntries.OrderByDescending(item => item.Date).Select(dto => dto.TaskId)
+                .Distinct().Take(5).ToList();
+            var taskResponses = new List<TaskResponseDto>();
+        
+            foreach (var taskId in mostRecentlyUsedTaskIds)
+            {
+                taskResponses.AddRange(await _taskService.GetTasksForUser(new TaskQuerySearch { Id = taskId }));
+            }
+
+            return taskResponses;
+        }
+    }
+}

--- a/packages/api/AlvTimeWebApi/Controllers/TasksController.cs
+++ b/packages/api/AlvTimeWebApi/Controllers/TasksController.cs
@@ -1,8 +1,10 @@
-﻿using AlvTime.Business.Tasks;
+﻿using System;
+using AlvTime.Business.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AlvTime.Business.TimeRegistration;
 using AlvTimeWebApi.Authorization;
 using AlvTimeWebApi.Requests;
 using AlvTimeWebApi.Responses;
@@ -15,23 +17,34 @@ namespace AlvTimeWebApi.Controllers;
 public class TasksController : Controller
 {
     private readonly TaskService _taskService;
+    private readonly LatestTaskService _latestTaskService;
 
-    public TasksController(TaskService taskService)
+    public TasksController(TaskService taskService, LatestTaskService latestTaskService)
     {
         _taskService = taskService;
+        _latestTaskService = latestTaskService;
     }
- 
+
     [HttpGet("Tasks")]
     public async Task<ActionResult<IEnumerable<TaskResponse>>> FetchTasks()
     {
         return Ok((await _taskService.GetTasksForUser(new TaskQuerySearch()))
-            .Select(task => new TaskResponse(task.Id, task.Name, task.Description, task.Favorite, task.Locked, task.CompensationRate, task.Project)));
+            .Select(task => new TaskResponse(task.Id, task.Name, task.Description, task.Favorite, task.Locked,
+                task.CompensationRate, task.Project)));
+    }
+
+    [HttpGet("LastUsedTasks")]
+    public async Task<ActionResult<IEnumerable<TaskResponse>>> FetchLastUsedTasks()
+    {
+        return Ok(await _latestTaskService.GetLatestTasksForUser());
     }
 
     [HttpPost("Tasks")]
-    public async Task<ActionResult<IEnumerable<TaskResponse>>> UpdateFavoriteTasks([FromBody] IEnumerable<TaskFavoriteRequest> tasksToBeUpdated)
+    public async Task<ActionResult<IEnumerable<TaskResponse>>> UpdateFavoriteTasks(
+        [FromBody] IEnumerable<TaskFavoriteRequest> tasksToBeUpdated)
     {
         var updatedTasks = await _taskService.UpdateFavoriteTasks(tasksToBeUpdated.Select(t => (t.Id, t.Favorite)));
-        return Ok(updatedTasks.Select(task => new TaskResponse(task.Id, task.Name, task.Description, task.Favorite, task.Locked, task.CompensationRate, task.Project)));
+        return Ok(updatedTasks.Select(task => new TaskResponse(task.Id, task.Name, task.Description, task.Favorite,
+            task.Locked, task.CompensationRate, task.Project)));
     }
 }

--- a/packages/api/Tests/UnitTests/AlvTimeDbContextBuilder.cs
+++ b/packages/api/Tests/UnitTests/AlvTimeDbContextBuilder.cs
@@ -226,6 +226,30 @@ namespace Tests.UnitTests
                 Locked = true
             });
 
+            _context.Task.Add(new Task
+            {
+                Id = 5,
+                Description = "",
+                Project = 2,
+                Name = "ExampleTaskFive"
+            });
+
+            _context.Task.Add(new Task
+            {
+                Id = 6,
+                Description = "",
+                Project = 2,
+                Name = "ExampleTaskSix"
+            });
+            
+            _context.Task.Add(new Task
+            {
+                Id = 7,
+                Description = "",
+                Project = 2,
+                Name = "ExampleTaskSeven"
+            });
+            
             _context.CompensationRate.Add(new CompensationRate
             {
                 TaskId = 1,
@@ -243,6 +267,27 @@ namespace Tests.UnitTests
             _context.CompensationRate.Add(new CompensationRate
             {
                 TaskId = 3,
+                Value = 0.5M,
+                FromDate = new DateTime(2019, 01 ,01)
+            });
+            
+            _context.CompensationRate.Add(new CompensationRate
+            {
+                TaskId = 5,
+                Value = 1.5M,
+                FromDate = new DateTime(2019, 01 ,01)
+            });
+
+            _context.CompensationRate.Add(new CompensationRate
+            {
+                TaskId = 6,
+                Value = 1.0M,
+                FromDate = new DateTime(2019, 01 ,01)
+            });
+            
+            _context.CompensationRate.Add(new CompensationRate
+            {
+                TaskId = 7,
                 Value = 0.5M,
                 FromDate = new DateTime(2019, 01 ,01)
             });

--- a/packages/api/Tests/UnitTests/Tasks/LatestTaskServiceTests.cs
+++ b/packages/api/Tests/UnitTests/Tasks/LatestTaskServiceTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using AlvTime.Business.Tasks;
+using AlvTime.Persistence.Repositories;
+using System.Linq;
+using AlvTime.Business.Options;
+using AlvTime.Business.TimeRegistration;
+using AlvTime.Persistence.DatabaseModels;
+using Moq;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+using User = AlvTime.Business.Users.User;
+using AlvTime.Business.Users;
+using AlvTime.Business.Utils;
+using Microsoft.Extensions.Options;
+
+namespace Tests.UnitTests.Tasks
+{
+    public class LatestTaskServiceTests
+    {
+        private readonly AlvTime_dbContext _context;
+        private readonly IOptionsMonitor<TimeEntryOptions> _options;
+        private readonly Mock<IUserContext> _userContextMock;
+        private readonly TimeRegistrationService _timeRegistrationService;
+        private readonly LatestTaskService _latestTaskService;
+
+        public LatestTaskServiceTests()
+        {
+            _context = new AlvTimeDbContextBuilder()
+                .WithTasks()
+                .WithLeaveTasks()
+                .WithProjects()
+                .WithUsers()
+                .WithCustomers()
+                .CreateDbContext();
+
+            var entryOptions = new TimeEntryOptions
+            {
+                SickDaysTask = 14,
+                PaidHolidayTask = 13,
+                UnpaidHolidayTask = 19,
+                FlexTask = 18,
+                StartOfOvertimeSystem = new DateTime(2020, 01, 01),
+                AbsenceProject = 9
+            };
+            _options = Mock.Of<IOptionsMonitor<TimeEntryOptions>>(options => options.CurrentValue == entryOptions);
+
+            _userContextMock = new Mock<IUserContext>();
+
+            var user = new User
+            {
+                Id = 1,
+                Email = "someone@alv.no",
+                Name = "Someone"
+            };
+
+            _timeRegistrationService = CreateTimeRegistrationService();
+            _latestTaskService = CreateLatestTaskService(_timeRegistrationService);
+
+            _userContextMock.Setup(context => context.GetCurrentUser())
+                .Returns(Task.FromResult(user));
+        }
+
+
+        private TimeRegistrationService CreateTimeRegistrationService()
+        {
+            return new TimeRegistrationService(_options, _userContextMock.Object, CreateTaskUtils(),
+                new TimeRegistrationStorage(_context), new DbContextScope(_context),
+                new PayoutStorage(_context, new DateAlvTime()),
+                new UserService(new UserRepository(_context), new TimeRegistrationStorage(_context)));
+        }
+
+        private LatestTaskService CreateLatestTaskService(TimeRegistrationService timeRegistrationService)
+        {
+            return new LatestTaskService(CreateTaskService(_context), timeRegistrationService);
+        }
+
+        private TaskUtils CreateTaskUtils()
+        {
+            return new TaskUtils(new TaskStorage(_context), _options);
+        }
+
+        [Fact]
+        public async Task ReturnLatestTasksWhenUserHasSubmittedTimeEntryOnTask()
+        {
+            var context = new AlvTimeDbContextBuilder()
+                .WithTasks()
+                .WithProjects()
+                .WithCustomers()
+                .CreateDbContext();
+
+            var taskService = CreateTaskService(context);
+
+            var tasks = await taskService.GetTasksForUser(new TaskQuerySearch());
+
+            var timeEntryDto = new CreateTimeEntryDto
+            {
+                Date = DateTime.Today,
+                Value = 7,
+                TaskId = tasks.First().Id
+            };
+
+            var latestTasksForUserBeforeUpdate = await _latestTaskService.GetLatestTasksForUser();
+            Assert.Empty(latestTasksForUserBeforeUpdate);
+
+            await _timeRegistrationService.UpsertTimeEntry(new List<CreateTimeEntryDto> { timeEntryDto });
+
+            var latestTasksForUser = await _latestTaskService.GetLatestTasksForUser();
+            Assert.Single(latestTasksForUser);
+        }
+
+        [Fact]
+        public async Task OnlyReturnUpTo5LatestTasks()
+        {
+            var context = new AlvTimeDbContextBuilder()
+                .WithTasks()
+                .WithProjects()
+                .WithCustomers()
+                .CreateDbContext();
+
+            var taskService = CreateTaskService(context);
+
+            var taskResponseDtos = (await taskService.GetTasksForUser(new TaskQuerySearch())).Where(dto => !dto.Locked).ToList();
+            foreach (var taskResponseDto in taskResponseDtos)
+            {
+                var timeEntryDto = new CreateTimeEntryDto
+                {
+                    Date = DateTime.Today,
+                    Value = 7,
+                    TaskId = taskResponseDto.Id
+                };
+                await _timeRegistrationService.UpsertTimeEntry(new List<CreateTimeEntryDto> { timeEntryDto });
+            }
+
+            Assert.Equal(6,taskResponseDtos.Count());
+
+            var latestTasksForUser = await _latestTaskService.GetLatestTasksForUser();
+            Assert.Equal(5, latestTasksForUser.ToList().Count);
+        }
+
+        [Fact]
+        public async Task CheckOnlyTheLatest30DaysWhenFindingLastTasks()
+        {
+            var context = new AlvTimeDbContextBuilder()
+                .WithTasks()
+                .WithProjects()
+                .WithCustomers()
+                .CreateDbContext();
+
+            var taskService = CreateTaskService(context);
+
+            var tasks = await taskService.GetTasksForUser(new TaskQuerySearch());
+
+            var timeEntryDto = new CreateTimeEntryDto
+            {
+                Date = DateTime.Today.AddDays(-31),
+                Value = 7,
+                TaskId = tasks.First().Id
+            };
+
+            var latestTasksForUserBeforeUpdate = await _latestTaskService.GetLatestTasksForUser();
+            Assert.Empty(latestTasksForUserBeforeUpdate);
+
+            await _timeRegistrationService.UpsertTimeEntry(new List<CreateTimeEntryDto> { timeEntryDto });
+
+            var latestTasksForUser = await _latestTaskService.GetLatestTasksForUser();
+            Assert.Empty(latestTasksForUser);
+        }
+
+        private static TaskService CreateTaskService(AlvTime_dbContext dbContext)
+        {
+            var mockUserContext = new Mock<IUserContext>();
+
+            var user = new User
+            {
+                Id = 1,
+                Email = "someone@alv.no",
+                Name = "Someone"
+            };
+
+            mockUserContext.Setup(context => context.GetCurrentUser()).Returns(Task.FromResult(user));
+            return new TaskService(new TaskStorage(dbContext), mockUserContext.Object);
+        }
+    }
+}


### PR DESCRIPTION
Introduced `LatestTaskService` to fetch recently used tasks for a user based on time entries within the last 30 days. Updated `TasksController` to include a new endpoint `FetchLastUsedTasks` and added necessary unit tests to ensure functionality.