### PR TITLE
Mer informative røde dager

### DIFF
--- a/packages/api/Tests/UnitTests/TimeEntries/TimeRegistrationServiceTests.cs
+++ b/packages/api/Tests/UnitTests/TimeEntries/TimeRegistrationServiceTests.cs
@@ -109,7 +109,7 @@ public class TimeRegistrationServiceTests
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task UpsertTimeEntry_RecordedVacationOnChristmas_CannotRegisterVactionOnRedDay()
+    public async System.Threading.Tasks.Task UpsertTimeEntry_RecordedVacationOnChristmas_CannotRegisterVacationOnRedDay()
     {
         var vacationEntry =
             CreateTimeEntryForExistingTask(new DateTime(2021, 12, 24), 7.5M, 13);
@@ -119,6 +119,7 @@ public class TimeRegistrationServiceTests
 
         Assert.False(timeEntryResult.IsSuccess);
         Assert.True(timeEntryResult.Errors.Any());
+        Assert.True(timeEntryResult.Errors.First().Description.Equals("Du trenger ikke føre ferie på helg eller røde dager"));
     }
 
     [Fact]

--- a/packages/frontend/src/services/holidays.ts
+++ b/packages/frontend/src/services/holidays.ts
@@ -50,8 +50,10 @@ function createNorwegianHolidaysForYear(yearNumber: number) {
     },
     { date: easter.clone().add(49, "days"), description: "Første pinsedag" },
     { date: easter.clone().add(50, "days"), description: "Andre pinsedag" },
+    { date: moment(yearString + "-12-24"), description: "Juleaften" },
     { date: moment(yearString + "-12-25"), description: "Første juledag" },
     { date: moment(yearString + "-12-26"), description: "Andre juledag" },
+    { date: moment(yearString + "-12-31"), description: "Nyttårsaften" },
   ];
 
   return norwegianHolidays;


### PR DESCRIPTION
- Markerer juleaften og nyttårsaften som røde dager frontend ettersom dette er fridager i Alv.
- Gir bedre feilmelding dersom man prøver å føre ferie på helg eller rød dag.