### PR TITLE
Kan kommentere på timer selv om de er låst pga utbetaling

### DIFF
--- a/packages/api/AlvTime.Business/TimeRegistration/ITimeRegistrationStorage.cs
+++ b/packages/api/AlvTime.Business/TimeRegistration/ITimeRegistrationStorage.cs
@@ -20,6 +20,7 @@ namespace AlvTime.Business.TimeRegistration
         Task<IEnumerable<TimeEntry>> GetFlexEntries(TimeEntryQuerySearch criteria);
         Task RegisterFlex(TimeEntry timeEntry, int userId);
         Task DeleteFlexOnDate(DateTime dateTime, int userId);
+        Task UpdateComment(string? comment, int hourId);
     }
 
     public class TimeEntryQuerySearch

--- a/packages/api/AlvTimeWebApi/Controllers/TimeEntriesController.cs
+++ b/packages/api/AlvTimeWebApi/Controllers/TimeEntriesController.cs
@@ -87,7 +87,7 @@ public class TimeEntriesController : Controller
                 Comment = timeEntry.Comment,
                 CommentedAt = timeEntry.CommentedAt
             })),
-            errors => BadRequest(errors.ToValidationProblemDetails("Timeføring feilet med følgende feil")));
+            errors => BadRequest(errors.ToValidationProblemDetails("Timeføring feilet. Eventuelle kommentarer har blitt oppdatert.")));
     }
         
     [HttpGet("FlexedHours")]

--- a/packages/api/Tests/UnitTests/Payouts/PayoutServiceTests.cs
+++ b/packages/api/Tests/UnitTests/Payouts/PayoutServiceTests.cs
@@ -221,7 +221,7 @@ public class PayoutServiceTests
         var payoutService = CreatePayoutServiceWithoutIncompleteDaysValidation(_timeRegistrationService);
         await payoutService.RegisterPayout(new GenericPayoutHourEntry
         {
-            Date = DateTime.Today.AddDays(-1),
+            Date = DateTime.Today,
             Hours = 10
         });
 


### PR DESCRIPTION
- Kan kommentere på eksisterende timer selv om de er låst
- Kan kommentere på ikke-eksisterende, låste timer kun hvis de føres med 0 timer
- Tar hensyn til at forventet antall timer i helg og på røde dager er 0 i ValidateTimeEntry
- Slår sammen noen valideringer som var like