### PR TITLE
Feature/expanded stats

### DIFF
--- a/packages/frontend/src/components/InvoiceChart.vue
+++ b/packages/frontend/src/components/InvoiceChart.vue
@@ -134,5 +134,5 @@ export default Vue.extend({
 #context {
   height: 100%;
   width: 100%;
-}</style
->>
+}
+</style>

--- a/packages/frontend/src/components/InvoiceStatistics.vue
+++ b/packages/frontend/src/components/InvoiceStatistics.vue
@@ -90,7 +90,7 @@ const invoiceStatisticPresets: InvoiceStatisticsPreset[] = [
 
 const granularityOptions = [
   {
-    value: InvoicePeriods.Annualy,
+    value: InvoicePeriods.Annually,
     label: "År",
   },
   {

--- a/packages/frontend/src/store/invoiceRate.ts
+++ b/packages/frontend/src/store/invoiceRate.ts
@@ -20,7 +20,7 @@ export enum InvoicePeriods {
   Daily = 0,
   Weekly = 1,
   Monthly = 2,
-  Annualy = 3,
+  Annually = 3,
 }
 
 export interface InvoiceStatisticsFilters {

--- a/packages/frontend/src/utils/timestamp-text-util.ts
+++ b/packages/frontend/src/utils/timestamp-text-util.ts
@@ -5,7 +5,7 @@ export const mapTimeStampToLabel = (
   granularity: InvoicePeriods
 ): string => {
   switch (granularity) {
-    case InvoicePeriods.Annualy:
+    case InvoicePeriods.Annually:
       return timeStamp.slice(0, 4);
     case InvoicePeriods.Monthly:
       return mapTimestampToMonthYearString(timeStamp);


### PR DESCRIPTION
This pull request introduces enhancements to the invoice statistics functionality, focusing on overtime hours tracking, and includes minor fixes for code consistency. The key changes involve adding support for tracking invoiceable and internal overtime hours, refactoring the `FETCH_INVOICE_STATISTICS` action to include overtime data, and correcting a typo in the `InvoicePeriods` enum.

### Enhancements to overtime hours tracking:
* Added `overtimeHours` to the `InvoiceStatistics` interface to track `invoiceableOvertimeHours` and `internalOvertimeHours` (`packages/frontend/src/store/invoiceRate.ts`, [packages/frontend/src/store/invoiceRate.tsR50-R53](diffhunk://#diff-4c61a240cc463b5f8948b9f65e7c7dd63b0247d8c2917412356c7d9b5e0397bbR50-R53)).
* Updated the `initStatistics` object to initialize `overtimeHours` with empty arrays (`packages/frontend/src/store/invoiceRate.ts`, [packages/frontend/src/store/invoiceRate.tsR74-R77](diffhunk://#diff-4c61a240cc463b5f8948b9f65e7c7dd63b0247d8c2917412356c7d9b5e0397bbR74-R77)).
* Added getters to calculate total values for `invoiceableOvertimeHours` and `internalOvertimeHours` (`packages/frontend/src/store/invoiceRate.ts`, [packages/frontend/src/store/invoiceRate.tsR163-R184](diffhunk://#diff-4c61a240cc463b5f8948b9f65e7c7dd63b0247d8c2917412356c7d9b5e0397bbR163-R184)).
* Implemented helper functions `getInvoiceableOvertimeHours` and `getInternalOvertimeHours` to filter and map overtime hours based on compensation rate and date range (`packages/frontend/src/store/invoiceRate.ts`, [packages/frontend/src/store/invoiceRate.tsR268-R314](diffhunk://#diff-4c61a240cc463b5f8948b9f65e7c7dd63b0247d8c2917412356c7d9b5e0397bbR268-R314)).
* Introduced `fetchOvertimeHours` to retrieve and process overtime data from the API (`packages/frontend/src/store/invoiceRate.ts`, [packages/frontend/src/store/invoiceRate.tsR268-R314](diffhunk://#diff-4c61a240cc463b5f8948b9f65e7c7dd63b0247d8c2917412356c7d9b5e0397bbR268-R314)).

### Refactoring of `FETCH_INVOICE_STATISTICS`:
* Refactored the `FETCH_INVOICE_STATISTICS` action to use `async/await` and include fetched overtime hours in the committed data (`packages/frontend/src/store/invoiceRate.ts`, F0e9cd74L194R234).

### Typo correction in `InvoicePeriods` enum:
* Fixed a typo in the `InvoicePeriods` enum by renaming `Annualy` to `Annually` and updated all references (`packages/frontend/src/store/invoiceRate.ts`, [[1]](diffhunk://#diff-4c61a240cc463b5f8948b9f65e7c7dd63b0247d8c2917412356c7d9b5e0397bbL23-R23); `packages/frontend/src/components/InvoiceStatistics.vue`, [[2]](diffhunk://#diff-ad8fe014d1c896abe840b007c8293631927945b13f696fec88920828114df941L93-R93); `packages/frontend/src/utils/timestamp-text-util.ts`, [[3]](diffhunk://#diff-03fe6e120b9c776861899d7f0de07a65fc2f15d188067fb63ab536e36b620330L8-R8).

### Minor fixes:
* Corrected a syntax issue in the `InvoiceChart.vue` component's `<style>` tag (`packages/frontend/src/components/InvoiceChart.vue`, [packages/frontend/src/components/InvoiceChart.vueL137-R138](diffhunk://#diff-054370c3053db71d811e9b57305b01b471ae0d7dcbf7ad253e6249c4381a9a73L137-R138)).