### PR TITLE
Displays project time summaries

### DIFF
--- a/packages/frontend-v3/src/components/StatusBar.vue
+++ b/packages/frontend-v3/src/components/StatusBar.vue
@@ -5,20 +5,20 @@
 				<HugeiconsIcon
 					:icon="Calendar03Icon"
 					class="icon"
-				/> 22,5/37,5
+				/> {{ totalHoursThisWeek }}/37,5
 			</div>
 			<div class="content-box flex">
 				<div>
 					<HugeiconsIcon
 						:icon="MoneyBag02Icon"
 						class="icon"
-					/> 4
+					/> {{ timeBankOverview?.availableHoursBeforeCompensation }}
 				</div>
 				<div>
 					<HugeiconsIcon
 						:icon="BeachIcon"
 						class="icon"
-					/> 20
+					/> {{ vacation?.availableVacationDays }}
 				</div>
 			</div>
 		</div>
@@ -26,8 +26,41 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted, computed } from "vue";
+import { useVacationStore } from "@/stores/vacationStore";
+import { useTimeBankStore } from "@/stores/timeBankStore";
+import { useDateStore } from "@/stores/dateStore";
+import { useTimeEntriesStore } from "@/stores/timeEntriesStore";
+import { storeToRefs } from "pinia";
 import { HugeiconsIcon } from "@hugeicons/vue";
 import { MoneyBag02Icon, BeachIcon, Calendar03Icon } from "@hugeicons/core-free-icons";
+import { isBetween } from "@/utils/dateHelper";
+
+const vacationStore = useVacationStore();
+const { vacation } = storeToRefs(vacationStore);
+
+const timeBankStore = useTimeBankStore();
+const { timeBankOverview } = storeToRefs(timeBankStore);
+
+const { timeEntries } = storeToRefs(useTimeEntriesStore());
+
+const { currentWeek } = storeToRefs(useDateStore());
+
+const totalHoursThisWeek = computed(() => {
+	console.log("Calculating total hours for the week", currentWeek.value);
+	return timeEntries.value.reduce((total, entry) => {
+		const entryDate = new Date(entry.date);
+		if (entryDate >= currentWeek.value[0] && entryDate <= currentWeek.value[6]) {
+			return total + entry.value;
+		}
+		return total;
+	}, 0);
+});
+
+onMounted(async () => {
+	await vacationStore.getVacationOverview();
+	await timeBankStore.getTimeBankOverview();
+});
 </script>
 
 <style scoped lang="scss">

--- a/packages/frontend-v3/src/components/StatusBar.vue
+++ b/packages/frontend-v3/src/components/StatusBar.vue
@@ -34,7 +34,6 @@ import { useTimeEntriesStore } from "@/stores/timeEntriesStore";
 import { storeToRefs } from "pinia";
 import { HugeiconsIcon } from "@hugeicons/vue";
 import { MoneyBag02Icon, BeachIcon, Calendar03Icon } from "@hugeicons/core-free-icons";
-import { isBetween } from "@/utils/dateHelper";
 
 const vacationStore = useVacationStore();
 const { vacation } = storeToRefs(vacationStore);

--- a/packages/frontend-v3/src/components/TimeTracker/TimeTracker.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/TimeTracker.vue
@@ -96,6 +96,7 @@ const getWeekNumberString = (date: Date) => {
 
 const currentSlideIndex = computed(() => {
 	if (swiper.value) {
+		dateStore.setActiveWeekIndex(swiper.value.activeIndex);
 		return swiper.value.activeIndex;
 	}
 	return 0;

--- a/packages/frontend-v3/src/components/TimeTracker/TimeTracker.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/TimeTracker.vue
@@ -40,13 +40,13 @@
 				>
 					<div class="project-list-wrapper">
 						<ProjectExpandable
-							v-for="project in taskStore.favoriteTasks"
+							v-for="project in taskStore.favoriteProjects"
 							:key="project.id"
 							:project="project"
 						>
 							<template #header>
 								<div class="project-stats">
-									Denne uken: 22,5t | Denne måneden: 145,5t
+									Denne uken: {{ allHoursInProjectThisWeek(project) }} | Denne måneden: {{ allHoursInProjectThisMonth(project) }}
 								</div>
 							</template>
 							<template #content>
@@ -73,15 +73,18 @@ import { onMounted, ref, computed } from "vue";
 import ProjectExpandable from "./ProjectExpandable.vue";
 import { useTaskStore } from "@/stores/taskStore";
 import { useDateStore } from "@/stores/dateStore";
+import { useTimeEntriesStore } from "@/stores/timeEntriesStore";
 import { getWeekNumber, getInitialWeekSlide} from "@/utils/weekHelper";
 import FeatherIcon from "@/components/utils/FeatherIcon.vue";
 import type Swiper from "swiper";
 import DayPillStrip from "./DayPillStrip.vue";
 import TaskStrip from "./TaskStrip.vue";
+import type { Project } from "@/types/ProjectTypes";
 
 const swiper = ref<Swiper | null>(null);
 const taskStore = useTaskStore();
 const dateStore = useDateStore();
+const timeEntriesStore = useTimeEntriesStore();
 
 const getWeekNumberString = (date: Date) => {
 	if(date.getFullYear() !== new Date().getFullYear()) {
@@ -104,6 +107,39 @@ const currentWeek = computed(() => {
 	}
 	return [];
 });
+
+const allHoursInProjectThisWeek = (project: Project) => {
+	const taskIds = project.tasks.map((task) => task.id);
+	const filteredTimeEntries = timeEntriesStore.timeEntries.filter((entry) =>
+		taskIds.includes(entry.taskId)
+	);
+
+	const totalHoursProjectThisWeek = filteredTimeEntries.reduce((total, entry) => {
+		const entryDate = new Date(entry.date);
+		if (entryDate >= currentWeek.value[0] && entryDate <= currentWeek.value[6]) {
+			return total + entry.value;
+		}
+		return total;
+	}, 0);
+
+	return `${totalHoursProjectThisWeek}t`;
+};
+
+const allHoursInProjectThisMonth = (project: Project) => {
+	const taskIds = project.tasks.map((task) => task.id);
+	const filteredTimeEntries = timeEntriesStore.timeEntries.filter((entry) =>
+		taskIds.includes(entry.taskId)
+	);
+
+	const totalHoursProjectThisMonth = filteredTimeEntries.reduce((total, entry) => {
+		if (entry.date.includes(`${currentWeek.value[0].getFullYear().toString()}-${(currentWeek.value[0].getMonth() + 1).toString().padStart(2, "0")}`)) {
+			return total + entry.value;
+		}
+		return total;
+	}, 0);
+
+	return `${totalHoursProjectThisMonth}t`;
+};
 
 const nextSlide = () => {
 	if (swiper.value) {

--- a/packages/frontend-v3/src/services/timeBankService.ts
+++ b/packages/frontend-v3/src/services/timeBankService.ts
@@ -1,0 +1,9 @@
+import { api } from "./apiClient";
+
+const timeBankService = {
+	getTimeBankOverview: async () => {
+		return await api.get("/api/user/AvailableHours");
+	},
+};
+
+export { timeBankService };

--- a/packages/frontend-v3/src/stores/dateStore.ts
+++ b/packages/frontend-v3/src/stores/dateStore.ts
@@ -13,6 +13,7 @@ export const useDateStore = defineStore("date", () => {
 	const weeks = ref<Date[][]>([]);
 	const holidays = ref<NorwegianHolidays>();
 	const swiper = ref<Swiper | null>(null);
+	const activeWeekIndex = ref<number>(0);
 
 	// Function to set the active date
 	const setActiveDate = async (date: Date) => {
@@ -21,6 +22,10 @@ export const useDateStore = defineStore("date", () => {
 		if (weeksDateRange.value) {
 			await timeEntriesStore.getTimeEntries(weeksDateRange.value);
 		}
+	};
+
+	const setActiveWeekIndex = (index: number) => {
+		activeWeekIndex.value = index;
 	};
 
 	const createWeeksInStore = async (activeDate: Date) => {
@@ -44,11 +49,17 @@ export const useDateStore = defineStore("date", () => {
 		swiper.value = swiperInstance;
 	};
 
+	const currentWeek = computed(() => {
+		return weeks.value[activeWeekIndex.value] || [];
+	});
+
 	return {
 		activeDate,
+		currentWeek,
 		weeks,
 		holidays,
 		setActiveDate,
+		setActiveWeekIndex,
 		setSwiper,
 	};
 });

--- a/packages/frontend-v3/src/stores/taskStore.ts
+++ b/packages/frontend-v3/src/stores/taskStore.ts
@@ -5,40 +5,40 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
 export const useTaskStore = defineStore("task", () => {
-	const tasks = ref<Project[] | null>(null);
+	const projects = ref<Project[] | null>(null);
 
 	const getTasks = async () => {
 		try {
 			const response = await taskService.getTasks();
 			if (response.status === 200) {
-				tasks.value = mutateTasks(response.data);
-				const updatedTasks = getLocalProjects(tasks.value);
+				projects.value = mutateTasks(response.data);
+				const updatedTasks = getLocalProjects(projects.value);
 				if (!updatedTasks) {
-					setLocalProjects(tasks.value ?? []);
+					setLocalProjects(projects.value ?? []);
 				} else {
-					tasks.value = updatedTasks;
+					projects.value = updatedTasks;
 				}
 			} else {
 				console.error("Failed to fetch tasks:", response.statusText);
-				tasks.value = [];
+				projects.value = [];
 			}
 		} catch (error) {
 			console.error("Error fetching tasks:", error);
-			tasks.value = [];
+			projects.value = [];
 		}
 	};
 
 	const updateTasks = async (tasksToUpdate: Task[]) => {
 		await taskService.updateTasks(tasksToUpdate);
-		setLocalProjects(tasks.value ?? []);
+		setLocalProjects(projects.value ?? []);
 	};
 
 	const toggleProjectExpandable = (projectId: string) => {
-		const project = tasks.value?.find((p: Project) => p.id === projectId);
+		const project = projects.value?.find((p: Project) => p.id === projectId);
 		if (project) {
 			project.open = !project.open;
 		}
-		setLocalProjects(tasks.value ?? []);
+		setLocalProjects(projects.value ?? []);
 	};
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -65,8 +65,8 @@ export const useTaskStore = defineStore("task", () => {
 		return projects;
 	};
 
-	const favoriteTasks = computed(() => {
-		const filteredProjects = tasks.value?.filter((project: Project) => {
+	const favoriteProjects = computed(() => {
+		const filteredProjects = projects.value?.filter((project: Project) => {
 			return project.tasks.some((task: Task) => task.favorite);
 		}) || [];
 
@@ -78,5 +78,5 @@ export const useTaskStore = defineStore("task", () => {
 		});
 	});
 
-	return { tasks, favoriteTasks, getTasks, updateTasks, toggleProjectExpandable };
+	return { projects, favoriteProjects, getTasks, updateTasks, toggleProjectExpandable };
 });

--- a/packages/frontend-v3/src/stores/timeBankStore.ts
+++ b/packages/frontend-v3/src/stores/timeBankStore.ts
@@ -1,0 +1,41 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { timeBankService } from "@/services/timeBankService";
+
+type TimeBankTransaction = {
+	availableHoursBeforeCompensation: number;
+	availableHoursAfterCompensation: number;
+	entries: TimeBankEntry[];
+};
+
+type TimeBankEntry = {
+	compensationRate: number;
+	date: string;
+	hours: number;
+	type: TransactionType;
+};
+
+const TransactionType = {
+	Overtime: 1,
+	Payout: 2,
+	Flex: 3,
+} as const;
+type TransactionType = typeof TransactionType[keyof typeof TransactionType];
+
+export const useTimeBankStore = defineStore("timeBank", () => {
+	const timeBankOverview = ref<TimeBankTransaction>();
+
+	const getTimeBankOverview = async () => {
+		try {
+			const response = await timeBankService.getTimeBankOverview();
+			timeBankOverview.value = response.data;
+		} catch (error) {
+			console.error("Failed to fetch time bank overview:", error);
+		}
+	};
+
+	return {
+		timeBankOverview,
+		getTimeBankOverview,
+	};
+});

--- a/packages/frontend-v3/src/stores/vacationStore.ts
+++ b/packages/frontend-v3/src/stores/vacationStore.ts
@@ -1,0 +1,39 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import absenceService from "@/services/absenceService";
+
+type Vacation = {
+	availableVacationDays: number;
+	availableVacationDaysTransferredFromLastYear: number;
+	usedVacationDaysThisYear: number;
+	plannedVacationDaysThisYear: number;
+	plannedTransactions: Transaction[];
+	usedTransactions: Transaction[];
+};
+
+type Transaction = {
+	comment: string;
+	commentedAt: string;
+	date: string;
+	id: number;
+	taskId: number;
+	user: number;
+	userEmail: string;
+	value: number;
+};
+
+export const useVacationStore = defineStore("vacation", () => {
+	const vacation = ref<Vacation>();
+
+	const getVacationOverview = async () => {
+		try {
+			const response = await absenceService.getVacationOverview();
+			vacation.value = response.data;
+		} catch (error) {
+			console.error("Failed to fetch vacation overview:", error);
+			throw error;
+		}
+	};
+
+	return { vacation, getVacationOverview };
+});

--- a/packages/frontend-v3/src/views/TaskView.vue
+++ b/packages/frontend-v3/src/views/TaskView.vue
@@ -6,7 +6,7 @@
 			class="project-list-wrapper"
 		>
 			<ProjectExpandable
-				v-for="project in taskStore.tasks"
+				v-for="project in taskStore.projects"
 				:key="project.id"
 				:project="project"
 			>


### PR DESCRIPTION
This pull request refactors the project and task management logic in the frontend to improve clarity and maintainability, and introduces dynamic calculation of tracked hours per project for the current week and month. The main changes include renaming the `tasks` store to `projects`, updating all related references, and adding utility functions to display project time statistics.

**Refactoring and renaming for clarity:**

* Renamed the main store property from `tasks` to `projects` in `taskStore`, and updated all references and return values accordingly to better reflect the data structure. [[1]](diffhunk://#diff-7fe260dda72b449b022915456683983b0c26119bf5c4c65c8384a3a456e4ff7eL8-R41) [[2]](diffhunk://#diff-7fe260dda72b449b022915456683983b0c26119bf5c4c65c8384a3a456e4ff7eL68-R69) [[3]](diffhunk://#diff-7fe260dda72b449b022915456683983b0c26119bf5c4c65c8384a3a456e4ff7eL81-R81) [[4]](diffhunk://#diff-d9378a062fb58ed5d29a12dd5911a349bdf88987b8dfffbb2464d94b69d307faL9-R9)

**Improved project statistics display:**

* Added two new computed functions, `allHoursInProjectThisWeek` and `allHoursInProjectThisMonth`, to dynamically calculate and display the total tracked hours for each project for the current week and month in the `TimeTracker` component.
* Updated the project list rendering in `TimeTracker.vue` to use `taskStore.favoriteProjects` and display real-time statistics using the new computed functions.

**Store usage updates:**

* Added import and usage of `useTimeEntriesStore` in `TimeTracker.vue` to access time entry data for statistics calculation.