### PR TITLE
Legger til UTC offset på commentedAt

### DIFF
--- a/packages/api/AlvTime.Business/TimeRegistration/TimeEntryResponseDto.cs
+++ b/packages/api/AlvTime.Business/TimeRegistration/TimeEntryResponseDto.cs
@@ -13,6 +13,6 @@ public class TimeEntryResponseDto
 
     public string? Comment { get; set; }
 
-    public DateTime? CommentedAt { get; set; }
+    public DateTimeOffset? CommentedAt { get; set; }
 
 }


### PR DESCRIPTION
**Endret fra DateTime til DateTimeOffset for å inkludere tidssone**

Kommentarer hadde tidligere kun tidspunkt i UTC uten informasjon om tidssone.

Ved å bytte fra DateTime til DateTimeOffset kan vi nå returnere både klokkeslett og tilhørende offset fra UTC, slik at klienter kan vise riktig tid uavhengig av hvor i verden kommentaren ble opprettet.

Closes #1017 