### PR TITLE
Enhances status bar with weekly hours summary

### DIFF
--- a/packages/frontend-v3/src/components/StatusBar.vue
+++ b/packages/frontend-v3/src/components/StatusBar.vue
@@ -104,7 +104,6 @@ onMounted(async () => {
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			min-width: 90px;
 			border-radius: 10px;
 			padding: 12px 12px 8px;
 			background-color: rgb(206 214 194);

--- a/packages/frontend-v3/src/components/StatusBar.vue
+++ b/packages/frontend-v3/src/components/StatusBar.vue
@@ -1,20 +1,20 @@
 <template>
 	<div class="status-bar-container">
 		<div class="column-box">
-			<div class="content-box">
-				<HugeiconsIcon
-					:icon="Calendar03Icon"
-					class="icon"
-				/> {{ totalHoursThisWeek }}/37,5
+			<div class="content-box super-index">
+				<WeekSummary
+					:totalHoursThisWeek="totalHoursThisWeek"
+					:totalHoursEachDayThisWeek="totalHoursEachDayThisWeek"
+				/>
 			</div>
 			<div class="content-box flex">
-				<div>
+				<div class="icon-wrapper">
 					<HugeiconsIcon
 						:icon="MoneyBag02Icon"
 						class="icon"
 					/> {{ timeBankOverview?.availableHoursBeforeCompensation }}
 				</div>
-				<div>
+				<div class="icon-wrapper">
 					<HugeiconsIcon
 						:icon="BeachIcon"
 						class="icon"
@@ -36,8 +36,9 @@ import { useDateStore } from "@/stores/dateStore";
 import { useTimeEntriesStore } from "@/stores/timeEntriesStore";
 import { storeToRefs } from "pinia";
 import { HugeiconsIcon } from "@hugeicons/vue";
-import { MoneyBag02Icon, BeachIcon, Calendar03Icon } from "@hugeicons/core-free-icons";
+import { MoneyBag02Icon, BeachIcon } from "@hugeicons/core-free-icons";
 import InvoiceRateVisualizer from "./utils/InvoiceRateVisualizer.vue";
+import WeekSummary from "./StatusBarComponents/WeekSummary.vue";
 
 const vacationStore = useVacationStore();
 const { vacation } = storeToRefs(vacationStore);
@@ -57,6 +58,22 @@ const totalHoursThisWeek = computed(() => {
 		}
 		return total;
 	}, 0);
+});
+
+const totalHoursEachDayThisWeek = computed(() => {
+	return currentWeek.value.map((date) => {
+		const totalForDay = timeEntries.value.reduce((total, entry) => {
+			const entryDate = new Date(entry.date);
+			if (entryDate.toDateString() === date.toDateString()) {
+				return total + entry.value;
+			}
+			return total;
+		}, 0);
+		return {
+			date: date,
+			hours: totalForDay
+		};
+	}).sort((a, b) => a.date.getTime() - b.date.getTime());
 });
 
 onMounted(async () => {
@@ -84,9 +101,12 @@ onMounted(async () => {
 		}
 
 		.content-box {
+			display: flex;
+			align-items: center;
+			justify-content: center;
 			min-width: 90px;
 			border-radius: 10px;
-			padding: 4px 16px 12px;
+			padding: 12px 12px 8px;
 			background-color: rgb(206 214 194);
 
 			&.flex {
@@ -94,11 +114,22 @@ onMounted(async () => {
 				justify-content: space-between;
 				gap: 16px;
 			}
+
+			&.super-index {
+				z-index: 10;
+			}
 		}
+	}
+
+	.icon-wrapper {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		width: max-content;
 	}
 
 	.icon {
 		position: relative;
-		top: 5px;
+		top: -2px;
 	}
 </style>

--- a/packages/frontend-v3/src/components/StatusBarComponents/WeekSummary.vue
+++ b/packages/frontend-v3/src/components/StatusBarComponents/WeekSummary.vue
@@ -1,0 +1,80 @@
+<template>
+	<div
+		class="week-summary"
+		@mouseover="hovering = true"
+		@mouseleave="hovering = false"
+	>
+		<div class="icon-wrapper">
+			<HugeiconsIcon
+				:icon="Calendar03Icon"
+				class="icon"
+			/> {{ totalHoursThisWeek }}/37,5
+		</div>
+		<div
+			class="expander"
+			:class="{ visible: hovering }"
+		>
+			<div
+				v-for="day in totalHoursEachDayThisWeek"
+				:key="day.date.toISOString()"
+			>
+				<span class="bold">{{ day.date.toLocaleDateString("nb-No", { weekday: "short" }).charAt(0).toUpperCase() }}</span>: {{ day.hours }}
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { HugeiconsIcon } from "@hugeicons/vue";
+import { Calendar03Icon } from "@hugeicons/core-free-icons";
+
+const hovering = ref(false);
+
+const { totalHoursThisWeek, totalHoursEachDayThisWeek } = defineProps<{
+	totalHoursThisWeek: number;
+	totalHoursEachDayThisWeek: { date: Date, hours: number }[];
+}>();
+</script>
+
+<style scoped lang="scss">
+.week-summary {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+.icon-wrapper {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+	width: max-content;
+}
+.icon {
+	position: relative;
+	top: -2px;
+}
+
+.expander {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 10px;
+	width: 0;
+	overflow: hidden;
+	transition: width .5s ease;
+
+	&.visible {
+		width: calc-size(auto, size);
+	}
+
+	div {
+		flex-grow: 1;
+		white-space: nowrap;
+
+		.bold {
+			font-weight: 700;
+		}
+	}
+}
+</style>

--- a/packages/frontend-v3/src/components/StatusBarComponents/WeekSummary.vue
+++ b/packages/frontend-v3/src/components/StatusBarComponents/WeekSummary.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		class="week-summary"
-		@mouseover="hovering = true"
+		@mouseenter="hovering = true"
 		@mouseleave="hovering = false"
 	>
 		<div class="icon-wrapper">
@@ -11,6 +11,7 @@
 			/> {{ totalHoursThisWeek }}/37,5
 		</div>
 		<div
+			id="expander"
 			class="expander"
 			:class="{ visible: hovering }"
 		>
@@ -25,7 +26,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { HugeiconsIcon } from "@hugeicons/vue";
 import { Calendar03Icon } from "@hugeicons/core-free-icons";
 
@@ -35,6 +36,21 @@ const { totalHoursThisWeek, totalHoursEachDayThisWeek } = defineProps<{
 	totalHoursThisWeek: number;
 	totalHoursEachDayThisWeek: { date: Date, hours: number }[];
 }>();
+
+const toggleExpander = () => {
+	const expander = document.getElementById("expander");
+	if (hovering.value) {
+		expander?.classList.add("visible");
+		expander?.style.setProperty("width", expander?.scrollWidth + "px");
+	} else {
+		expander?.classList.remove("visible");
+		expander?.style.setProperty("width", "0");
+	}
+};
+
+watch(hovering, () => {
+	toggleExpander();
+});
 </script>
 
 <style scoped lang="scss">
@@ -63,10 +79,6 @@ const { totalHoursThisWeek, totalHoursEachDayThisWeek } = defineProps<{
 	width: 0;
 	overflow: hidden;
 	transition: width .5s ease;
-
-	&.visible {
-		width: calc-size(auto, size);
-	}
 
 	div {
 		flex-grow: 1;

--- a/packages/frontend-v3/src/components/TimeTracker/TrackRestOfDayButton.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/TrackRestOfDayButton.vue
@@ -11,8 +11,6 @@
 import { defineProps, defineEmits, onMounted, ref } from "vue";
 import { useTimeEntriesStore } from "@/stores/timeEntriesStore";
 
-// TODO: Use this to calculate the remaining time in the workday based on all tasks.
-
 const timeLeftInWorkday = ref<number>(0);
 const timeEntriesStore = useTimeEntriesStore();
 

--- a/packages/frontend-v3/src/components/utils/InvoiceRateVisualizer.vue
+++ b/packages/frontend-v3/src/components/utils/InvoiceRateVisualizer.vue
@@ -22,7 +22,7 @@ const { invoiceRate } = storeToRefs(timeEntriesStore);
 
 const currentPeriod = computed(() => {
 	const now = new Date();
-	const month = now.toLocaleString("default", { month: "short" });
+	const month = now.toLocaleString("nb-NO", { month: "short" });
 	const year = now.getFullYear() - 2000;
 	return `${month} '${year}`;
 });


### PR DESCRIPTION
This pull request refactors the weekly hours display in the `StatusBar.vue` component by introducing a new `WeekSummary` subcomponent. The change improves the user experience by showing a breakdown of hours per day in a hoverable expander, and also updates related styling and data calculation logic.

**Component refactoring and UI improvements:**

* Replaced the inline weekly hours display in `StatusBar.vue` with a new `WeekSummary` component that shows both total hours and a per-day breakdown on hover. (`[[1]](diffhunk://#diff-d307dcaddcd6effe74158eaafff578aa62be09e54a579bd0e2ee8af86bd36b79L4-R17)`, `[[2]](diffhunk://#diff-227896e3a28e6f4d9aaacaf5201093f7ec0f1bedaf80acdeede7d104a70e1f08R1-R80)`)
* Added the `WeekSummary.vue` component, which displays the total hours for the week and expands to show hours for each day when hovered. (`[packages/frontend-v3/src/components/StatusBarComponents/WeekSummary.vueR1-R80](diffhunk://#diff-227896e3a28e6f4d9aaacaf5201093f7ec0f1bedaf80acdeede7d104a70e1f08R1-R80)`)

**Logic and data calculation updates:**

* Added a new computed property `totalHoursEachDayThisWeek` in `StatusBar.vue` to calculate daily hours for the current week, sorted by date. (`[packages/frontend-v3/src/components/StatusBar.vueR63-R78](diffhunk://#diff-d307dcaddcd6effe74158eaafff578aa62be09e54a579bd0e2ee8af86bd36b79R63-R78)`)

**Styling enhancements:**

* Updated styles in `StatusBar.vue` to improve layout, alignment, and z-index management for the new summary and icon wrappers. (`[packages/frontend-v3/src/components/StatusBar.vueR104-R133](diffhunk://#diff-d307dcaddcd6effe74158eaafff578aa62be09e54a579bd0e2ee8af86bd36b79R104-R133)`)
* Refined icon and expander styles in `WeekSummary.vue` for better visual consistency and interaction feedback. (`[packages/frontend-v3/src/components/StatusBarComponents/WeekSummary.vueR1-R80](diffhunk://#diff-227896e3a28e6f4d9aaacaf5201093f7ec0f1bedaf80acdeede7d104a70e1f08R1-R80)`)

**Code cleanup:**

* Removed the unused `Calendar03Icon` import from `StatusBar.vue` and added the import to `WeekSummary.vue` where it is now used. (`[[1]](diffhunk://#diff-d307dcaddcd6effe74158eaafff578aa62be09e54a579bd0e2ee8af86bd36b79L39-R41)`, `[[2]](diffhunk://#diff-227896e3a28e6f4d9aaacaf5201093f7ec0f1bedaf80acdeede7d104a70e1f08R1-R80)`)