### PR TITLE
Persists project sort order to database

### DIFF
--- a/packages/frontend-v3/src/components/TimeTracker/ProjectExpandable.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/ProjectExpandable.vue
@@ -42,10 +42,10 @@ import { useTaskStore } from "@/stores/taskStore";
 const taskStore = useTaskStore();
 
 const toggleExpand = () => {
-	taskStore.toggleProjectExpandable(`${project.name}-${project.customerName}`);
+	taskStore.toggleProjectExpandable(`${props.project.name}-${props.project.customerName}`);
 };
 
-const { project } = defineProps<{
+const props = defineProps<{
 	project: Project;
 }>();
 </script>

--- a/packages/frontend-v3/src/components/TimeTracker/ProjectSorter.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/ProjectSorter.vue
@@ -64,8 +64,12 @@ const updateList = async (evt: any) => {
 	const newProjectOrder = favoriteProjects.value.map(
 		(project) => { return { id: project.id, index: project.index ?? 0 }; }
 	);
+	try {
+		await taskService.updateProjectFavoriteOrder(newProjectOrder);
+	} catch (error) {
+		console.error("Failed to update project order:", error);
+	}
 
-	await taskService.updateProjectFavoriteOrder(newProjectOrder);
 	taskStore.saveFavoritesOrderToProjects();
 };
 

--- a/packages/frontend-v3/src/components/TimeTracker/ProjectSorter.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/ProjectSorter.vue
@@ -36,6 +36,7 @@ import { Sortable } from "sortablejs-vue3";
 import ProjectSorterStrip from "./ProjectSorterStrip.vue";
 import { storeToRefs } from "pinia";
 import FeatherIcon from "@/components/utils/FeatherIcon.vue";
+import taskService from "@/services/taskService";
 
 const taskStore = useTaskStore();
 const { favoriteProjects } = storeToRefs(taskStore);
@@ -48,15 +49,24 @@ const closeSorter = () => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const updateList = (evt: any) => {
-	const moveItemInArray = <T>(array: T[], from: number, to: number) => {
+const updateList = async (evt: any) => {
+	const moveItemInArray = <T extends { index?: number }>(array: T[], from: number, to: number) => {
 		const item = array.splice(from, 1)[0];
 		array.splice(to, 0, item);
+		array = array.map((item, index) => {
+			item.index = index;
+			return item;
+		});
 	};
 
 	const { oldIndex, newIndex } = evt;
 	moveItemInArray(favoriteProjects.value, oldIndex, newIndex);
-	taskStore.setFavoriteProjectsOrder();
+	const newProjectOrder = favoriteProjects.value.map(
+		(project) => { return { id: project.id, index: favoriteProjects.value.indexOf(project) }; }
+	);
+
+	await taskService.updateProjectFavoriteOrder(newProjectOrder);
+	taskStore.saveFavoritesOrderToProjects();
 };
 
 </script>

--- a/packages/frontend-v3/src/components/TimeTracker/ProjectSorter.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/ProjectSorter.vue
@@ -62,7 +62,7 @@ const updateList = async (evt: any) => {
 	const { oldIndex, newIndex } = evt;
 	moveItemInArray(favoriteProjects.value, oldIndex, newIndex);
 	const newProjectOrder = favoriteProjects.value.map(
-		(project) => { return { id: project.id, index: favoriteProjects.value.indexOf(project) }; }
+		(project) => { return { id: project.id, index: project.index ?? 0 }; }
 	);
 
 	await taskService.updateProjectFavoriteOrder(newProjectOrder);

--- a/packages/frontend-v3/src/composables/useLocalStorage.ts
+++ b/packages/frontend-v3/src/composables/useLocalStorage.ts
@@ -1,7 +1,6 @@
 import type { Project } from "@/types/ProjectTypes";
 
 const setLocalProjects = (value: Project[]): void => {
-	console.log("Setting local projects:", value);
 	const localProjects = value.map(project => ({
 		id: `${project.name}-${project.customerName}`,
 		open: project.open,

--- a/packages/frontend-v3/src/composables/useLocalStorage.ts
+++ b/packages/frontend-v3/src/composables/useLocalStorage.ts
@@ -1,10 +1,10 @@
 import type { Project } from "@/types/ProjectTypes";
 
 const setLocalProjects = (value: Project[]): void => {
+	console.log("Setting local projects:", value);
 	const localProjects = value.map(project => ({
 		id: `${project.name}-${project.customerName}`,
 		open: project.open,
-		index: project.index || 0,
 	}));
 
 	localStorage.setItem("projects", JSON.stringify(localProjects));
@@ -23,7 +23,6 @@ const getLocalProjects = (projects: Project[]): Project[] | null => {
 				return {
 					...project,
 					open: localProject?.open ?? false,
-					index: localProject?.index
 				};
 			});
 		} catch (error) {

--- a/packages/frontend-v3/src/services/taskService.ts
+++ b/packages/frontend-v3/src/services/taskService.ts
@@ -4,4 +4,6 @@ import type { Task } from "@/types/ProjectTypes";
 export default {
 	getProjects: async () => api.get("/api/user/projects"),
 	updateTasks: async (tasks: Task[]) =>  api.post("/api/user/tasks", tasks),
+	updateProjectFavoriteOrder: async (projectOrder: { id: string; index: number }[]) =>
+		api.put("/api/user/project/favorites", projectOrder),
 };

--- a/packages/frontend-v3/src/stores/taskStore.ts
+++ b/packages/frontend-v3/src/stores/taskStore.ts
@@ -73,13 +73,13 @@ export const useTaskStore = defineStore("task", () => {
 			});
 	};
 
-	const saveFavoritesOrderToProjects = async () => {
+	const saveFavoritesOrderToProjects = () => {
 		if (!projects.value) return;
 
 		projects.value.forEach((project) => {
 			const favoriteProject = favoriteProjects.value.find(fp => fp.id === project.id);
 			if (favoriteProject) {
-				project.index = favoriteProject?.index;
+				project.index = favoriteProject.index;
 			}
 		});
 	};

--- a/packages/frontend-v3/src/stores/taskStore.ts
+++ b/packages/frontend-v3/src/stores/taskStore.ts
@@ -53,16 +53,9 @@ export const useTaskStore = defineStore("task", () => {
 		if (project) {
 			project.open = !project.open;
 		}
+
 		setLocalProjects(projects.value ?? []);
 		setFavoriteProjects();
-	};
-
-	const setFavoriteProjectsOrder = () => {
-		for (const [index, project] of (favoriteProjects.value ?? []).entries()) {
-			project.index = index;
-		}
-
-		setLocalProjects(favoriteProjects.value ?? []);
 	};
 
 	const setFavoriteProjects = () => {
@@ -78,6 +71,17 @@ export const useTaskStore = defineStore("task", () => {
 			.filter((project): project is Project => project !== null).sort((a, b) => {
 				return (a.index ?? 0) - (b.index ?? 0);
 			});
+	};
+
+	const saveFavoritesOrderToProjects = async () => {
+		if (!projects.value) return;
+
+		projects.value.forEach((project) => {
+			const favoriteProject = favoriteProjects.value.find(fp => fp.id === project.id);
+			if (favoriteProject) {
+				project.index = favoriteProject?.index;
+			}
+		});
 	};
 
 	const filteredProjects = computed(() => {
@@ -117,6 +121,6 @@ export const useTaskStore = defineStore("task", () => {
 		getTasks,
 		updateTasks,
 		toggleProjectExpandable,
-		setFavoriteProjectsOrder,
+		saveFavoritesOrderToProjects,
 	};
 });


### PR DESCRIPTION
Saves the order of favorite projects to the database when the user reorders them in the project sorter.

This ensures that the project order is consistent across sessions and devices. The index is added to the projects and then passed to the api to persist in the database.