### PR TITLE
Lagrer ikke auth state in cookie

### DIFF
--- a/packages/frontend-v3/src/authConfig.ts
+++ b/packages/frontend-v3/src/authConfig.ts
@@ -10,7 +10,8 @@ export const msalConfig = {
 		postLogoutRedirectUri: "/" // Must be registered as a SPA redirectURI on your app registration
 	},
 	cache: {
-		cacheLocation: "localStorage"
+		cacheLocation: "localStorage",
+		storeAuthStateInCookie: false,
 	},
 	system: {
 		loggerOptions: {

--- a/packages/frontend-v3/src/services/apiClient.ts
+++ b/packages/frontend-v3/src/services/apiClient.ts
@@ -1,41 +1,36 @@
 import axios from "axios";
 import config from "@/config";
 import { msalInstance } from "@/authConfig";
-import { InteractionRequiredAuthError } from "@azure/msal-browser";
 
 const getAccessToken = async () => {
 	const accounts = msalInstance.getAllAccounts();
 	if (accounts.length > 0) {
 		const account = accounts[0];
-		try{
 			const response = await msalInstance.acquireTokenSilent({
 				scopes: [config.ACCESS_SCOPE],
 				account: account,
 			});
 
 			return response.accessToken;
-
-		} catch (e) {
-			if (e instanceof InteractionRequiredAuthError) {
-				await msalInstance.loginPopup({
-					scopes: [config.ACCESS_SCOPE],
-					account: account,
-				});
-			}
-		}
 	} else {
 		throw new Error("No accounts found");
 	}
 };
 
-const token = await getAccessToken();
-
 const api = axios.create({
 	baseURL: config.API_HOST,
-	headers: {
-		"Authorization": `Bearer ${token}`
-	}
 });
+
+api.interceptors.request.use(
+    async (config) => {
+        const token = await getAccessToken();
+        config.headers.Authorization = `Bearer ${token}`;
+        return config;
+    },
+    (error) => {
+        return Promise.reject(error);
+    }
+);
 
 export {
 	api

--- a/packages/frontend-v3/src/services/apiClient.ts
+++ b/packages/frontend-v3/src/services/apiClient.ts
@@ -1,17 +1,28 @@
 import axios from "axios";
 import config from "@/config";
 import { msalInstance } from "@/authConfig";
+import { InteractionRequiredAuthError } from "@azure/msal-browser";
 
 const getAccessToken = async () => {
 	const accounts = msalInstance.getAllAccounts();
 	if (accounts.length > 0) {
 		const account = accounts[0];
-		const response = await msalInstance.acquireTokenSilent({
-			scopes: [config.ACCESS_SCOPE],
-			account: account,
-		});
+		try{
+			const response = await msalInstance.acquireTokenSilent({
+				scopes: [config.ACCESS_SCOPE],
+				account: account,
+			});
 
-		return response.accessToken;
+			return response.accessToken;
+
+		} catch (e) {
+			if (e instanceof InteractionRequiredAuthError) {
+				await msalInstance.loginPopup({
+					scopes: [config.ACCESS_SCOPE],
+					account: account,
+				});
+			}
+		}
 	} else {
 		throw new Error("No accounts found");
 	}


### PR DESCRIPTION
Går bort fra å lagre auth state i cookie. Legger til token som header via interceptor istedet for ved opprettelse av API client. Catcher InteractionRequiredAuthError og forcer en login redirect. Krever refresh fra bruker, men fjerne issue med cookie som må slettes.