### PR TITLE
Issue 1018: Dynamisk legg til og fjern redirectUri i App Registration + CORS policy

### DIFF
--- a/.github/scripts/addRedirectUri.ps1
+++ b/.github/scripts/addRedirectUri.ps1
@@ -1,0 +1,23 @@
+param (
+    [string]$uriToAdd,
+    [string]$appRegistrationClientId
+)
+# Fetch existing redirect URIs from App Registration
+$existingRedirectUris = az ad app show --id $appRegistrationClientId --query spa.redirectUris 
+
+# Remove whitespace, quotes, and brackets, then split into an array
+$cleanedRedirectUriList = $existingRedirectUris | Out-String | ForEach-Object { $_ -replace '\s', '' } | ForEach-Object { $_ -replace '"', '' } | ForEach-Object { $_ -replace '\[|\]', '' } | ForEach-Object { $_.Split(',') }
+
+if ($cleanedRedirectUriList -contains $uriToAdd) {
+    Write-Host "The URI '$uriToAdd' already exists in the redirect URIs. No action taken."
+    exit 0
+}
+
+$urisToSet = $cleanedRedirectUriList + $uriToAdd
+
+# Set up the argument correctly with proper formatting
+$uriListString = $urisToSet -join "','"
+$setArgument = "spa={'redirectUris': ['" + $uriListString + "']}"
+
+# Set the new list of RedirectUris in the App Registration
+az ad app update --id $appRegistrationClientId --set $setArgument

--- a/.github/scripts/removeRedirectUri.ps1
+++ b/.github/scripts/removeRedirectUri.ps1
@@ -1,0 +1,21 @@
+param (
+    [string]$numberPR,
+    [string]$appRegistrationClientId
+)
+
+# Fetch existing redirect URIs from App Registration
+$existingRedirectUrisList = az ad app show --id $appRegistrationClientId --query spa.redirectUris
+
+# Remove whitespace, quotes, and brackets, then split into an array
+$cleanedRedirectUriList = $existingRedirectUrisList | Out-String | ForEach-Object { $_ -replace '\s', '' } | ForEach-Object { $_ -replace '"', '' } | ForEach-Object { $_ -replace '\[|\]', '' } | ForEach-Object { $_.Split(',') }
+
+# Filter out the URI that contains the specified PR number
+$filter = "-" + $numberPR + "."
+$filteredList = $cleanedRedirectUriList | Where-Object { $_ -notmatch $filter }
+
+# Set up the argument correctly with proper formatting
+$uriListString = $filteredList -join "','"
+$setArgument = "spa={'redirectUris': ['" + $uriListString + "']}"
+
+# Set the new list of RedirectUris in the App Registration
+az ad app update --id $appRegistrationClientId --set $setArgument

--- a/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
+++ b/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
@@ -16,7 +16,9 @@ on:
 
 jobs:
   build_and_deploy_job:
-    # if: ${{github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')}}
+    if: ${{github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')}}
+    permissions:
+      id-token: write # Require write permission to fetch OIDC token when using Azure Login action
     runs-on: ubuntu-latest
     name: Build and Deploy to Test Job
     environment: test
@@ -40,7 +42,17 @@ jobs:
           app_location: "./packages/frontend-v3" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "dist" # Built app content directory - optional
-          ###### End of Repository/Build Configurations ######
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+      - name: Make script executable
+        run: chmod +x .github/scripts/addRedirectUri.ps1
+      - name: Add site to redirectUris script
+        shell: pwsh
+        run: .github/scripts/addRedirectUri.ps1 -uriToAdd ${{ steps.builddeploy.outputs.static_web_app_url }} -appRegistrationClientId ${{ secrets.AZURE_FRONTEND_APP_REGISTRATION_CLIENT_ID }}
 
   close_pull_request_job:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}

--- a/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
+++ b/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build and Deploy to Test Job
     environment: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: true
           lfs: false	
@@ -69,7 +69,7 @@ jobs:
     name: Close Pull Request Job
     environment: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Close Pull Request
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
+++ b/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
@@ -56,10 +56,13 @@ jobs:
 
   close_pull_request_job:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    permissions:
+      id-token: write # Require write permission to fetch OIDC token when using Azure Login action
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     environment: test
     steps:
+      - uses: actions/checkout@v3
       - name: Close Pull Request
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
@@ -67,3 +70,14 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.STATICWEBAPP_V3_DEPLOYMENT_TOKEN }}
           app_location: "./packages/frontend-v3" # App source code path
           action: "close"
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+      - name: Make script executable
+        run: chmod +x .github/scripts/removeRedirectUri.ps1
+      - name: Remove site from redirectUris script
+        shell: pwsh
+        run: .github/scripts/removeRedirectUri.ps1 -numberPR ${{ github.event.pull_request.number }} -appRegistrationClientId ${{ secrets.AZURE_FRONTEND_APP_REGISTRATION_CLIENT_ID }}

--- a/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
+++ b/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
@@ -45,14 +45,17 @@ jobs:
           api_location: "" # Api source code path - optional
           output_location: "dist" # Built app content directory - optional
       - name: Azure Login
+        if: ${{ steps.builddeploy.conclusion == 'success' }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
       - name: Make script executable
+        if: ${{ steps.builddeploy.conclusion == 'success' }}
         run: chmod +x .github/scripts/addRedirectUri.ps1
       - name: Add site to redirectUris script
+        if: ${{ steps.builddeploy.conclusion == 'success' }}
         shell: pwsh
         run: .github/scripts/addRedirectUri.ps1 -uriToAdd ${{ steps.builddeploy.outputs.static_web_app_url }} -appRegistrationClientId ${{ secrets.AZURE_FRONTEND_APP_REGISTRATION_CLIENT_ID }}
 

--- a/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
+++ b/.github/workflows/azure-static-web-apps-zealous-wave-0708ca403.yml
@@ -19,6 +19,8 @@ jobs:
     if: ${{github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')}}
     permissions:
       id-token: write # Require write permission to fetch OIDC token when using Azure Login action
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Build and Deploy to Test Job
     environment: test
@@ -58,6 +60,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
     permissions:
       id-token: write # Require write permission to fetch OIDC token when using Azure Login action
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     environment: test

--- a/packages/api/AlvTimeWebApi/Cors/CorsExtensions.cs
+++ b/packages/api/AlvTimeWebApi/Cors/CorsExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Net.Http.Headers;
@@ -8,6 +9,7 @@ namespace AlvTimeWebApi.Cors
     {
 
         public static string DevCorsPolicyName => "devCorsPolicyName";
+        public static string TestCorsPolicyName => "testCorsPolicyName";
 
         public static void AddAlvtimeCorsPolicys(this IServiceCollection services, IConfiguration configuration)
         {
@@ -23,6 +25,23 @@ namespace AlvTimeWebApi.Cors
                             .AllowAnyMethod();
                     }
                 );
+                
+                options.AddPolicy(TestCorsPolicyName, builder =>
+                {
+                    builder
+                        .SetIsOriginAllowed(origin =>
+                        {
+                            if (Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+                            {
+                                return uri.Scheme == Uri.UriSchemeHttps &&
+                                       uri.Host.EndsWith(".westeurope.2.azurestaticapps.net");
+                            }
+
+                            return false;
+                        })
+                        .WithHeaders(HeaderNames.ContentType, HeaderNames.Authorization)
+                        .AllowAnyMethod();
+                });
 
                 options.AddPolicy(name: DevCorsPolicyName,
                     builder =>

--- a/packages/api/AlvTimeWebApi/EnvironmentExtensions.cs
+++ b/packages/api/AlvTimeWebApi/EnvironmentExtensions.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace AlvTimeWebApi;
+
+public static class EnvironmentExtensions
+{
+    private const string TestEnvironment = "Test";
+    
+    public static bool IsTest(this IHostEnvironment hostEnvironment)
+    {
+        return hostEnvironment.IsEnvironment(TestEnvironment);
+    }
+}

--- a/packages/api/AlvTimeWebApi/Startup.cs
+++ b/packages/api/AlvTimeWebApi/Startup.cs
@@ -62,7 +62,7 @@ public class Startup
 
         app.UseRouting();
 
-        if (env.IsDevelopment())
+        if (env.IsDevelopment() || env.IsTest())
         {
             app.UseCors(CorsExtensions.DevCorsPolicyName);
         }

--- a/packages/api/AlvTimeWebApi/Startup.cs
+++ b/packages/api/AlvTimeWebApi/Startup.cs
@@ -62,9 +62,14 @@ public class Startup
 
         app.UseRouting();
 
-        if (env.IsDevelopment() || env.IsTest())
+        if (env.IsDevelopment())
         {
             app.UseCors(CorsExtensions.DevCorsPolicyName);
+        }
+        else if (env.IsTest())
+        {
+            app.UseCors(CorsExtensions.TestCorsPolicyName);
+            app.UseHttpsRedirection();
         }
         else
         {

--- a/packages/frontend-v3/src/components/NavigationBar.vue
+++ b/packages/frontend-v3/src/components/NavigationBar.vue
@@ -103,8 +103,8 @@ const close = () => {
 		width: 1200px;
 		padding: 0 20px;
 		display: flex;
-		justify-content: space-between;
 		align-items: center;
+		justify-content: space-between;
 
 		a {
 			text-decoration: none;


### PR DESCRIPTION
Når PR opprettes så legges til den dynamisk genererte url-en til App Registration sin liste over godkjente redirectUris. 
I tillegg til endring i CORS policy for test-miljø så kan man logge inn på disse PR-spesifikke applikasjonene.

Når PR lukkes så fjernes url-en fra listen over godkjente redirectUris.

For å teste denne funksjonaliteten så er nok enkleste måte å lage en ny PR av denne branchen også lukke den. 