### PR TITLE
View for PAT management

### DIFF
--- a/packages/api/AlvTime.Business/AccessTokens/AccessTokenService.cs
+++ b/packages/api/AlvTime.Business/AccessTokens/AccessTokenService.cs
@@ -31,21 +31,14 @@ namespace AlvTime.Business.AccessTokens
             return await _tokenStorage.CreateLifetimeToken(personalAccessToken);
         }
 
-        public async Task<IEnumerable<AccessTokenDto>> DeleteActiveTokens(IEnumerable<int> tokenIds)
+        public async Task DeleteToken(int tokenId)
         {
             var userTokenIds = (await GetActiveTokens()).Select(token => token.Id);
-
-            var response = new List<AccessTokenDto>();
-
-            foreach (var tokenId in tokenIds)
+            
+            if (userTokenIds.Contains(tokenId))
             {
-                if (userTokenIds.Contains(tokenId))
-                {
-                    response.Add(await _tokenStorage.DeleteActiveTokens(tokenId));
-                }
+                await _tokenStorage.DeleteActiveToken(tokenId);
             }
-
-            return response;
         }
 
         public async Task<IEnumerable<AccessTokenDto>> GetActiveTokens()

--- a/packages/api/AlvTime.Business/AccessTokens/IAccessTokenStorage.cs
+++ b/packages/api/AlvTime.Business/AccessTokens/IAccessTokenStorage.cs
@@ -7,7 +7,7 @@ namespace AlvTime.Business.AccessTokens
     public interface IAccessTokenStorage
     {
         Task<IEnumerable<AccessTokenDto>> GetActiveTokens(User user);
-        Task<AccessTokenDto> DeleteActiveTokens(int tokenId);
+        Task<AccessTokenDto> DeleteActiveToken(int tokenId);
         Task<AccessTokenDto> CreateLifetimeToken(PersonalAccessToken token);
     }
 }

--- a/packages/api/AlvTime.Persistence/Repositories/AccessTokenStorage.cs
+++ b/packages/api/AlvTime.Persistence/Repositories/AccessTokenStorage.cs
@@ -34,7 +34,7 @@ namespace AlvTime.Persistence.Repositories
             return new AccessTokenDto(accessToken.Id, accessToken.Value, accessToken.ExpiryDate, accessToken.FriendlyName);
         }
 
-        public async Task<AccessTokenDto> DeleteActiveTokens(int tokenId)
+        public async Task<AccessTokenDto> DeleteActiveToken(int tokenId)
         {
             var token = _dbContext.AccessTokens
                 .FirstOrDefault(t => t.Id == tokenId);

--- a/packages/api/AlvTimeWebApi/Controllers/AccessTokenController.cs
+++ b/packages/api/AlvTimeWebApi/Controllers/AccessTokenController.cs
@@ -31,14 +31,12 @@ namespace AlvTimeWebApi.Controllers
             return Ok(new AccessTokenCreatedResponse(accessToken.Token, accessToken.ExpiryDate.ToDateOnly()));
         }
 
-        [HttpDelete("AccessToken")]
-        public async Task<ActionResult<IEnumerable<AccessTokenFriendlyNameResponse>>> DeleteAccessToken(
-            [FromBody] IEnumerable<AccessTokenDeleteRequest> tokenIds)
+        [HttpDelete("AccessToken/{tokenId}")]
+        public async Task<ActionResult> DeleteAccessToken(int tokenId)
         {
-            var accessTokens = await _tokenService.DeleteActiveTokens(tokenIds.Select(tokenId => tokenId.TokenId));
+            await _tokenService.DeleteToken(tokenId);
 
-            return Ok(accessTokens.Select(token =>
-                new AccessTokenFriendlyNameResponse(token.Id, token.FriendlyName, token.ExpiryDate.ToDateOnly())));
+            return NoContent();
         }
 
         [HttpGet("ActiveAccessTokens")]

--- a/packages/api/Tests/UnitTests/AccessToken/AccessTokenServiceTests.cs
+++ b/packages/api/Tests/UnitTests/AccessToken/AccessTokenServiceTests.cs
@@ -51,7 +51,7 @@ public class AccessTokenServiceTests
     {
         var service = CreateAccessTokenService(_context);
 
-        await service.DeleteActiveTokens(new List<int>{1});
+        await service.DeleteToken(new List<int>{1});
 
         var tokens = await service.GetActiveTokens();
 

--- a/packages/api/Tests/UnitTests/AccessToken/AccessTokenServiceTests.cs
+++ b/packages/api/Tests/UnitTests/AccessToken/AccessTokenServiceTests.cs
@@ -51,7 +51,7 @@ public class AccessTokenServiceTests
     {
         var service = CreateAccessTokenService(_context);
 
-        await service.DeleteToken(new List<int>{1});
+        await service.DeleteToken(1);
 
         var tokens = await service.GetActiveTokens();
 

--- a/packages/frontend-v3/src/components/NavigationBar.vue
+++ b/packages/frontend-v3/src/components/NavigationBar.vue
@@ -44,6 +44,13 @@
 						Statistikk
 					</router-link>
 				</div>
+        <div>
+          <router-link
+            to="/pat"
+          >
+            PAT
+          </router-link>
+        </div>
 			</div>
 			<div class="user-container">
 				<p>{{ user?.name }}</p>

--- a/packages/frontend-v3/src/router/index.ts
+++ b/packages/frontend-v3/src/router/index.ts
@@ -35,6 +35,14 @@ const routes: Array<RouteRecordRaw> = [
 		}
 	},
 	{
+		path: "/pat",
+		name: "pat",
+		component: () => import("@/views/AccessTokenView.vue"),
+		meta: {
+			requiresAuth: true,
+		}
+	},
+	{
 		path: "/failed",
 		name: "failed",
 		component: () => import("@/views/HomeView.vue"),

--- a/packages/frontend-v3/src/services/accessTokenService.ts
+++ b/packages/frontend-v3/src/services/accessTokenService.ts
@@ -3,7 +3,6 @@
 export default {
   getAccessTokens: () => api.get("/api/user/ActiveAccessTokens"),
   createAccessToken: (data: { friendlyName: string }) => {
-    console.log("Service: createAccessToken called with:", data);
     return api.post("/api/user/AccessToken", data);
   },
   deleteAccessToken: (tokenId: number) => api.delete(`/api/user/AccessToken/${tokenId}`)

--- a/packages/frontend-v3/src/services/accessTokenService.ts
+++ b/packages/frontend-v3/src/services/accessTokenService.ts
@@ -1,0 +1,10 @@
+﻿import { api } from "@/services/apiClient.ts";
+
+export default {
+  getAccessTokens: () => api.get("/api/user/ActiveAccessTokens"),
+  createAccessToken: (data: { friendlyName: string }) => {
+    console.log("Service: createAccessToken called with:", data);
+    return api.post("/api/user/AccessToken", data);
+  },
+  deleteAccessToken: (tokenId: number) => api.delete(`/api/user/AccessToken/${tokenId}`)
+};

--- a/packages/frontend-v3/src/stores/accessTokenStore.ts
+++ b/packages/frontend-v3/src/stores/accessTokenStore.ts
@@ -1,0 +1,49 @@
+﻿import { defineStore } from "pinia";
+import { ref } from "vue";
+import accessTokenService from "@/services/accessTokenService.ts";
+
+export type PersonalAccessToken = {
+  id: number;
+  friendlyName: string;
+  expiryDate: Date;
+}
+
+export type CreatedTokenResponse = {
+  token: string;
+  expiryDate: Date;
+}
+
+export const useAccessTokenStore = defineStore('accessTokenStore', () => {
+  const accessTokens = ref<PersonalAccessToken[]>([])
+
+  const getAccessTokens = async () => {
+    try {
+      const response = await accessTokenService.getAccessTokens();
+      accessTokens.value = response.data;
+    } catch (error) {
+      console.error("Failed to fetch statistics:", error);
+      throw error;
+    }
+  };
+
+  const createAccessToken = async (friendlyName: string): Promise<CreatedTokenResponse | undefined> => {
+    try {
+      const response = await accessTokenService.createAccessToken({ friendlyName });
+      await getAccessTokens();
+      return response.data;
+    } catch (error) {
+      console.error("Failed to create access token:", error);
+    }
+  }
+
+  const deleteAccessToken = async (id: number) => {
+    try {
+      await accessTokenService.deleteAccessToken(id);
+      await getAccessTokens();
+    } catch (error) {
+      console.error("Failed to delete access token:", error);
+    }
+  }
+
+  return { accessTokens, getAccessTokens, createAccessToken, deleteAccessToken }
+})

--- a/packages/frontend-v3/src/stores/accessTokenStore.ts
+++ b/packages/frontend-v3/src/stores/accessTokenStore.ts
@@ -21,7 +21,7 @@ export const useAccessTokenStore = defineStore('accessTokenStore', () => {
       const response = await accessTokenService.getAccessTokens();
       accessTokens.value = response.data;
     } catch (error) {
-      console.error("Failed to fetch statistics:", error);
+      console.error("Failed to fetch access tokens:", error);
       throw error;
     }
   };

--- a/packages/frontend-v3/src/views/AccessTokenView.vue
+++ b/packages/frontend-v3/src/views/AccessTokenView.vue
@@ -1,0 +1,267 @@
+﻿<template>
+<div v-if="!loading">
+  <h1>Personal access tokens</h1>
+  <div class="description">
+    Personlige access token fungerer akkurat som OAuth tilgangstoken for å
+    autentisere deg mot Alvtime API. Bruk de som bearer tokens i
+    applikasjoner der det ikke er mulig eller praktisk å implementere login
+    på vanlig måte.
+  </div>
+  <div class="form-container">
+    <div class="form-row">
+    <input
+      id="create-pat"
+      v-model="tokenName"
+      type="string"
+      placeholder="Navn på nytt token"
+      @focus="onInputFocus"
+    />
+    <button
+      :disabled="tokenName.length <= 0"
+      @click="createToken"
+    >
+      Lag token
+    </button>
+    </div>
+    <div v-if="temporaryVisibleToken" class="new-token-container">
+      <b>Kopiér opprettet token og lagre det. Tokenet vil ikke kunne vises på nytt.</b>
+      <p>Token: <b>{{ temporaryVisibleToken.token }}</b></p>
+      <p>Utgår: {{ formatDate(temporaryVisibleToken.expiryDate) }}</p>
+      <div class="copy-button-wrapper">
+
+      <AlvtimeButton iconRight @click="copyTokenToClipboard">
+        Kopiér <FeatherIcon name="clipboard" />
+      </AlvtimeButton>
+      <span v-if="showCopiedTooltip" class="copied-tooltip">Kopiert!</span>
+      </div>
+    </div>
+  </div>
+  <div class="table-container">
+    <h3>Eksisterende tokens</h3>
+    <table class="token-table">
+      <thead>
+      <tr>
+        <th>Navn</th>
+        <th>Utgår</th>
+        <th></th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr v-for="token in accessTokens" :key="token.friendlyName">
+        <td>{{ token.friendlyName }}</td>
+        <td>{{ formatDate(token.expiryDate) }}</td>
+        <td class="action-cell">
+          <button class="delete-btn" @click="deleteToken(token.id)" title="Slett token">
+            <FeatherIcon name="trash-2" />
+          </button>
+        </td>
+      </tr>
+      <tr v-if="accessTokens.length === 0">
+        <td colspan="2">Ingen tokens funnet</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</template>
+
+<script setup lang="ts">
+import { type CreatedTokenResponse, useAccessTokenStore } from "@/stores/accessTokenStore.ts";
+import { storeToRefs } from "pinia";
+import { onMounted, ref } from "vue";
+import AlvtimeButton from "@/components/utils/AlvtimeButton.vue";
+import FeatherIcon from "@/components/utils/FeatherIcon.vue";
+
+const accessTokenStore = useAccessTokenStore();
+const { accessTokens } = storeToRefs(accessTokenStore);
+const loading = ref<boolean>(true);
+const tokenName = ref<string>("");
+let temporaryVisibleToken = ref<CreatedTokenResponse | null>(null);
+const showCopiedTooltip = ref(false);
+
+const createToken = async () => {
+  const createdToken = await accessTokenStore.createAccessToken(tokenName.value);
+  if (createdToken){
+    temporaryVisibleToken.value = createdToken;
+    tokenName.value = "";
+  }
+}
+
+const deleteToken = async (tokenId: number) => {
+  await accessTokenStore.deleteAccessToken(tokenId);
+}
+
+const onInputFocus = () => {
+  const inputElement = document.getElementById("create-pat") as HTMLInputElement;
+  inputElement.select();
+};
+
+const copyTokenToClipboard = () => {
+  if (temporaryVisibleToken.value) {
+    navigator.clipboard.writeText(temporaryVisibleToken.value.token);
+    showCopiedTooltip.value = true;
+    setTimeout(() => {
+      showCopiedTooltip.value = false;
+    }, 2500);
+  }
+}
+
+function formatDate(date: Date): string {
+  return new Date(date).toLocaleDateString("nb-NO", {
+    day: "numeric",
+    month: "short",
+    year: "numeric"
+  });
+}
+
+onMounted( async () => {
+  await accessTokenStore.getAccessTokens();
+  loading.value = false;
+});
+</script>
+
+<style scoped lang="scss">
+.form-container {
+  margin-top: 16px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.form-row {
+  display: flex;
+  gap: 16px;
+  width: 100%;
+
+  input {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 25px;
+    flex: auto;
+    text-align: center;
+  }
+
+  button {
+    background-color: $secondary-color;
+    color: $primary-color;
+    border-radius: 25px;
+    border: none;
+    padding: 13px 24px 13px 24px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+
+    &:hover {
+      background-color: $secondary-color-light;
+      color: $primary-color;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.new-token-container {
+  padding: 1rem;
+  background-color: $secondary-color-light;
+  border-radius: 0.5rem;
+}
+
+.table-container {
+  padding: 0.2rem 0.5rem 1.0rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  border: 3px solid $secondary-color;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.token-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th, td {
+    padding: 0.75rem;
+    border-bottom: 1px solid #e0e0e0;
+  }
+
+  th {
+    font-weight: bold;
+    background-color: $secondary-color-light;
+  }
+
+  td {
+    text-align: center;
+  }
+
+  .action-cell {
+    width: 1%;
+    white-space: nowrap;
+    padding: 0.5rem;
+  }
+}
+
+
+.delete-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.4rem;
+  color: #888;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s, background-color 0.2s;
+
+  &:hover {
+    color: #c53030;
+    background-color: rgba(197, 48, 48, 0.1);
+  }
+}
+
+.copy-button-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.copied-tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #333;
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 13px;
+  white-space: nowrap;
+  margin-bottom: 8px;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #333;
+  }
+}
+
+.description {
+  margin: 1rem auto;
+  max-width: 48rem;
+  padding: 1rem 1.5rem;
+  background-color: rgba($secondary-color-light, 0.3);
+  border-left: 4px solid $secondary-color;
+  border-radius: 0 0.5rem 0.5rem 0;
+  color: #555;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+</style>

--- a/packages/frontend-v3/src/views/AccessTokenView.vue
+++ b/packages/frontend-v3/src/views/AccessTokenView.vue
@@ -1,78 +1,104 @@
 ﻿<template>
-<div v-if="!loading">
-  <h1>Personal access tokens</h1>
-  <div class="description">
-    Personlige access token fungerer akkurat som OAuth tilgangstoken for å
-    autentisere deg mot Alvtime API. Bruk de som bearer tokens i
-    applikasjoner der det ikke er mulig eller praktisk å implementere login
-    på vanlig måte.
-  </div>
-  <div class="form-container">
-    <div class="form-row">
-    <input
-      id="create-pat"
-      v-model="tokenName"
-      type="string"
-      placeholder="Navn på nytt token"
-      @focus="onInputFocus"
-    />
-    <button
-      :disabled="tokenName.length <= 0"
-      @click="createToken"
-    >
-      Lag token
-    </button>
-    </div>
-    <div v-if="temporaryVisibleToken" class="new-token-container">
-      <b>Kopiér opprettet token og lagre det. Tokenet vil ikke kunne vises på nytt.</b>
-      <p>Token: <b>{{ temporaryVisibleToken.token }}</b></p>
-      <p>Utgår: {{ formatDate(temporaryVisibleToken.expiryDate) }}</p>
-      <div class="copy-button-wrapper">
-
-      <AlvtimeButton iconRight @click="copyTokenToClipboard">
-        Kopiér <FeatherIcon name="clipboard" />
-      </AlvtimeButton>
-      <span v-if="showCopiedTooltip" class="copied-tooltip">Kopiert!</span>
-      </div>
-    </div>
-  </div>
-  <div class="table-container">
-    <h3>Eksisterende tokens</h3>
-    <table class="token-table">
-      <thead>
-      <tr>
-        <th>Navn</th>
-        <th>Utgår</th>
-        <th></th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr v-for="token in accessTokens" :key="token.id">
-        <td>{{ token.friendlyName }}</td>
-        <td>{{ formatDate(token.expiryDate) }}</td>
-        <td class="action-cell">
-          <div class="action-buttons">
-            <template v-if="confirmingDeleteId === token.id">
-              <button class="delete-btn confirm-btn" @click="confirmDelete(token.id)" title="Bekreft sletting">
-                <FeatherIcon name="check" />
-              </button>
-              <button class="delete-btn cancel-btn" @click="cancelDelete" title="Avbryt">
-                <FeatherIcon name="x" />
-              </button>
-            </template>
-          <button v-if="confirmingDeleteId !== token.id" class="delete-btn" @click="requestDelete(token.id)" title="Slett token">
-            <FeatherIcon name="trash-2" />
-          </button>
-          </div>
-        </td>
-      </tr>
-      <tr v-if="accessTokens.length === 0">
-        <td colspan="2">Ingen tokens funnet</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
+	<div v-if="!loading">
+		<h1>Personal access tokens</h1>
+		<div class="description">
+			Personlige access token fungerer akkurat som OAuth tilgangstoken for å
+			autentisere deg mot Alvtime API. Bruk de som bearer tokens i
+			applikasjoner der det ikke er mulig eller praktisk å implementere login
+			på vanlig måte.
+		</div>
+		<div class="form-container">
+			<div class="form-row">
+				<input
+					id="create-pat"
+					v-model="tokenName"
+					type="string"
+					placeholder="Navn på nytt token"
+					@focus="onInputFocus"
+				/>
+				<button
+					:disabled="tokenName.length <= 0"
+					@click="createToken"
+				>
+					Lag token
+				</button>
+			</div>
+			<div
+				v-if="temporaryVisibleToken"
+				class="new-token-container"
+			>
+				<b>Kopiér opprettet token og lagre det. Tokenet vil ikke kunne vises på nytt.</b>
+				<p>Token: <b>{{ temporaryVisibleToken.token }}</b></p>
+				<p>Utgår: {{ formatDate(temporaryVisibleToken.expiryDate) }}</p>
+				<div class="copy-button-wrapper">
+					<AlvtimeButton 
+						iconRight 
+						@click="copyTokenToClipboard"
+					>
+						Kopiér <FeatherIcon name="clipboard" />
+					</AlvtimeButton>
+					<span
+						v-if="showCopiedTooltip"
+						class="copied-tooltip"
+					>Kopiert!</span>
+				</div>
+			</div>
+		</div>
+		<div class="table-container">
+			<h3>Eksisterende tokens</h3>
+			<table class="token-table">
+				<thead>
+					<tr>
+						<th>Navn</th>
+						<th>Utgår</th>
+						<th />
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						v-for="token in accessTokens"
+						:key="token.id"
+					>
+						<td>{{ token.friendlyName }}</td>
+						<td>{{ formatDate(token.expiryDate) }}</td>
+						<td class="action-cell">
+							<div class="action-buttons">
+								<template v-if="confirmingDeleteId === token.id">
+									<button
+										class="delete-btn confirm-btn"
+										title="Bekreft sletting"
+										@click="confirmDelete(token.id)"
+									>
+										<FeatherIcon name="check" />
+									</button>
+									<button
+										class="delete-btn cancel-btn"
+										title="Avbryt"
+										@click="cancelDelete"
+									>
+										<FeatherIcon name="x" />
+									</button>
+								</template>
+								<button
+									v-if="confirmingDeleteId !== token.id"
+									class="delete-btn"
+									title="Slett token"
+									@click="requestDelete(token.id)"
+								>
+									<FeatherIcon name="trash-2" />
+								</button>
+							</div>
+						</td>
+					</tr>
+					<tr v-if="accessTokens.length === 0">
+						<td colspan="2">
+							Ingen tokens funnet
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
 </template>
 
 <script setup lang="ts">
@@ -91,52 +117,52 @@ const showCopiedTooltip = ref(false);
 const confirmingDeleteId = ref<number | null>(null);
 
 const createToken = async () => {
-  const createdToken = await accessTokenStore.createAccessToken(tokenName.value);
-  if (createdToken){
-    temporaryVisibleToken.value = createdToken;
-    tokenName.value = "";
-  }
-}
+	const createdToken = await accessTokenStore.createAccessToken(tokenName.value);
+	if (createdToken){
+		temporaryVisibleToken.value = createdToken;
+		tokenName.value = "";
+	}
+};
 
 const requestDelete = (tokenId: number) => {
-  confirmingDeleteId.value = tokenId;
+	confirmingDeleteId.value = tokenId;
 };
 
 const confirmDelete = async (tokenId: number) => {
-  await accessTokenStore.deleteAccessToken(tokenId);
-  confirmingDeleteId.value = null;
+	await accessTokenStore.deleteAccessToken(tokenId);
+	confirmingDeleteId.value = null;
 };
 
 const cancelDelete = () => {
-  confirmingDeleteId.value = null;
+	confirmingDeleteId.value = null;
 };
 
 const onInputFocus = () => {
-  const inputElement = document.getElementById("create-pat") as HTMLInputElement;
-  inputElement.select();
+	const inputElement = document.getElementById("create-pat") as HTMLInputElement;
+	inputElement.select();
 };
 
 const copyTokenToClipboard = () => {
-  if (temporaryVisibleToken.value) {
-    navigator.clipboard.writeText(temporaryVisibleToken.value.token);
-    showCopiedTooltip.value = true;
-    setTimeout(() => {
-      showCopiedTooltip.value = false;
-    }, 2500);
-  }
-}
+	if (temporaryVisibleToken.value) {
+		navigator.clipboard.writeText(temporaryVisibleToken.value.token);
+		showCopiedTooltip.value = true;
+		setTimeout(() => {
+			showCopiedTooltip.value = false;
+		}, 2500);
+	}
+};
 
 function formatDate(date: Date): string {
-  return new Date(date).toLocaleDateString("nb-NO", {
-    day: "numeric",
-    month: "short",
-    year: "numeric"
-  });
+	return new Date(date).toLocaleDateString("nb-NO", {
+		day: "numeric",
+		month: "short",
+		year: "numeric"
+	});
 }
 
 onMounted( async () => {
-  await accessTokenStore.getAccessTokens();
-  loading.value = false;
+	await accessTokenStore.getAccessTokens();
+	loading.value = false;
 });
 </script>
 

--- a/packages/frontend-v3/src/views/AccessTokenView.vue
+++ b/packages/frontend-v3/src/views/AccessTokenView.vue
@@ -47,13 +47,23 @@
       </tr>
       </thead>
       <tbody>
-      <tr v-for="token in accessTokens" :key="token.friendlyName">
+      <tr v-for="token in accessTokens" :key="token.id">
         <td>{{ token.friendlyName }}</td>
         <td>{{ formatDate(token.expiryDate) }}</td>
         <td class="action-cell">
-          <button class="delete-btn" @click="deleteToken(token.id)" title="Slett token">
+          <div class="action-buttons">
+            <template v-if="confirmingDeleteId === token.id">
+              <button class="delete-btn confirm-btn" @click="confirmDelete(token.id)" title="Bekreft sletting">
+                <FeatherIcon name="check" />
+              </button>
+              <button class="delete-btn cancel-btn" @click="cancelDelete" title="Avbryt">
+                <FeatherIcon name="x" />
+              </button>
+            </template>
+          <button v-if="confirmingDeleteId !== token.id" class="delete-btn" @click="requestDelete(token.id)" title="Slett token">
             <FeatherIcon name="trash-2" />
           </button>
+          </div>
         </td>
       </tr>
       <tr v-if="accessTokens.length === 0">
@@ -76,8 +86,9 @@ const accessTokenStore = useAccessTokenStore();
 const { accessTokens } = storeToRefs(accessTokenStore);
 const loading = ref<boolean>(true);
 const tokenName = ref<string>("");
-let temporaryVisibleToken = ref<CreatedTokenResponse | null>(null);
+const temporaryVisibleToken = ref<CreatedTokenResponse | null>(null);
 const showCopiedTooltip = ref(false);
+const confirmingDeleteId = ref<number | null>(null);
 
 const createToken = async () => {
   const createdToken = await accessTokenStore.createAccessToken(tokenName.value);
@@ -87,9 +98,18 @@ const createToken = async () => {
   }
 }
 
-const deleteToken = async (tokenId: number) => {
+const requestDelete = (tokenId: number) => {
+  confirmingDeleteId.value = tokenId;
+};
+
+const confirmDelete = async (tokenId: number) => {
   await accessTokenStore.deleteAccessToken(tokenId);
-}
+  confirmingDeleteId.value = null;
+};
+
+const cancelDelete = () => {
+  confirmingDeleteId.value = null;
+};
 
 const onInputFocus = () => {
   const inputElement = document.getElementById("create-pat") as HTMLInputElement;
@@ -222,6 +242,22 @@ onMounted( async () => {
     color: #c53030;
     background-color: rgba(197, 48, 48, 0.1);
   }
+}
+
+.action-buttons {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: center;
+}
+
+.confirm-btn:hover {
+  color: #2f855a;
+  background-color: rgba(47, 133, 90, 0.1);
+}
+
+.cancel-btn:hover {
+  color: #c53030;
+  background-color: rgba(197, 48, 48, 0.1);
 }
 
 .copy-button-wrapper {


### PR DESCRIPTION
This pull request introduces a new Personal Access Token (PAT) management feature to the frontend, enabling users to view, create, and delete their own tokens through a dedicated UI. The most important changes are as follows:

**Frontend: Personal Access Token Management**
- Added a new `AccessTokenView.vue` page that allows users to list, create, and delete their personal access tokens, complete with user-friendly UI elements and copy-to-clipboard functionality.
- Introduced a new route (`/pat`) and navigation link for accessing the PAT management page. [[1]](diffhunk://#diff-e8e7af33714bb20e9c364a685f6ba593391581d194e11779b71daf0fa4763aedR37-R44) [[2]](diffhunk://#diff-d926968a6d0566ca2d4bc213112e0731ad9ce403247b619d54d72b982ac5601eR47-R53)
- Implemented a Pinia store (`accessTokenStore.ts`) and service (`accessTokenService.ts`) to handle fetching, creating, and deleting tokens via the API. [[1]](diffhunk://#diff-9e00828d8bdbb266c9f1dc2ae6dcf6e5bdb0b2de264b2161453166dc9221daaeR1-R49) [[2]](diffhunk://#diff-832dae5b7c35e78c43ab18fdca1608b82c8711b6d428851b9ba64bb01370edb9R1-R10)