### PR TITLE
Ny autorisering i Scalar

### DIFF
--- a/packages/api/AlvTimeWebApi/AlvTimeWebApi.csproj
+++ b/packages/api/AlvTimeWebApi/AlvTimeWebApi.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="Microsoft.Graph" Version="5.79.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.12.37" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/api/AlvTimeWebApi/Authorization/DefaultHeaderTransformer.cs
+++ b/packages/api/AlvTimeWebApi/Authorization/DefaultHeaderTransformer.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AlvTimeWebApi.Authorization;
+
+public class DefaultHeaderTransformer : IOpenApiOperationTransformer
+{
+    public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+    {
+        operation.Parameters ??= [];
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "X-CSRF",
+            In = ParameterLocation.Header,
+            Description = "Custom header will enforce preflight and mitigate som XSS-attacks",
+            Required = true,
+            Schema = new OpenApiSchema
+            {
+                Type = "string"
+            },
+            Example = new Microsoft.OpenApi.Any.OpenApiString("1")
+        });
+
+        return Task.CompletedTask;
+    }
+}

--- a/packages/api/AlvTimeWebApi/Authorization/OpenApiLoginTransformer.cs
+++ b/packages/api/AlvTimeWebApi/Authorization/OpenApiLoginTransformer.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AlvTimeWebApi.Authorization;
+
+public class OpenApiLoginTransformer(IHostEnvironment environment) : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(
+        OpenApiDocument document,
+        OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        if (environment.IsDevelopment())
+        {
+            document.Info.Description = "<a href=\"http://localhost:8081/api/auth/login?returnUrl=http://localhost:8081/scalar/v1\">Trykk her for å autorisere</a>";
+        }
+        else if (environment.IsTest())
+        {
+            document.Info.Description = "<a href=\"https://api.test-alvtime.no/api/auth/login?returnUrl=https://api.test-alvtime.no/scalar/v1\">Trykk her for å autorisere</a>";
+        }
+        else if (environment.IsProduction())
+        {
+            document.Info.Description = "<a href=\"https://api.alvtime.no/api/auth/login?returnUrl=https://api.alvtime.no/scalar/v1\">Trykk her for å autorisere</a>";
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/packages/api/AlvTimeWebApi/Properties/launchSettings.json
+++ b/packages/api/AlvTimeWebApi/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:8082;http://localhost:8081"
+      "applicationUrl": "http://localhost:8081"
     },
     "Docker": {
       "commandName": "Docker",

--- a/packages/api/AlvTimeWebApi/Startup.cs
+++ b/packages/api/AlvTimeWebApi/Startup.cs
@@ -9,7 +9,6 @@ using AlvTimeWebApi.Infrastructure;
 using AlvTimeWebApi.Logging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,7 +45,11 @@ public class Startup
         services.AddScoped<GraphService>();
         services.Configure<TimeEntryOptions>(Configuration.GetSection("TimeEntryOptions"));
         services.AddAlvtimeAuthorization();
-        services.AddOpenApi(o => o.AddDocumentTransformer<OpenApiLoginTransformer>());
+        services.AddOpenApi(o => 
+        {
+            o.AddDocumentTransformer<OpenApiLoginTransformer>();
+            o.AddOperationTransformer<DefaultHeaderTransformer>();
+        });
         services.AddRazorPages();
         services.AddAlvtimeCorsPolicys(Configuration);
         services.ConfigureLogging(_environment);
@@ -95,8 +98,7 @@ public class Startup
                 options
                     .WithTheme(ScalarTheme.Kepler)
                     .WithTitle("AlvTime API")
-                    .WithFavicon("/assets/favicon.ico")
-                    .WithDarkModeToggle(true);
+                    .WithFavicon("/assets/favicon.ico");
             });
         });
     }

--- a/packages/api/AlvTimeWebApi/Startup.cs
+++ b/packages/api/AlvTimeWebApi/Startup.cs
@@ -9,14 +9,12 @@ using AlvTimeWebApi.Infrastructure;
 using AlvTimeWebApi.Logging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Scalar.AspNetCore;
-using System.Net;
-using Microsoft.AspNetCore.Http;
 
 namespace AlvTimeWebApi;
 
@@ -48,7 +46,7 @@ public class Startup
         services.AddScoped<GraphService>();
         services.Configure<TimeEntryOptions>(Configuration.GetSection("TimeEntryOptions"));
         services.AddAlvtimeAuthorization();
-        services.AddOpenApi();
+        services.AddOpenApi(o => o.AddDocumentTransformer<OpenApiLoginTransformer>());
         services.AddRazorPages();
         services.AddAlvtimeCorsPolicys(Configuration);
         services.ConfigureLogging(_environment);
@@ -95,11 +93,6 @@ public class Startup
             endpoints.MapScalarApiReference(options =>
             {
                 options
-                    .WithOAuth2Authentication(oAuth2Options =>
-                    {
-                        oAuth2Options.ClientId = Configuration["AzureAd:ClientId"];
-                        oAuth2Options.Scopes = [Configuration["AzureAd:Domain"]];
-                    })
                     .WithTheme(ScalarTheme.Kepler)
                     .WithTitle("AlvTime API")
                     .WithFavicon("/assets/favicon.ico")


### PR DESCRIPTION
Denne PRen tar for seg å benytte den nye innloggingsflyten når man skal bruke Scalar.

Jeg har lagt ved en link som brukeren skal trykke på for å starte innloggingsflyten slik at man får autentiserings-cookien i browseren.
Har også lagt til en default header "X-CSRF" på alle endepunkt i Scalar, siden dette er et krav av APIet etter endring av innloggingsflyt

<img width="343" height="205" alt="image" src="https://github.com/user-attachments/assets/2c6488ef-cdb2-47fa-8af5-2720e978e4f5" />
<img width="730" height="130" alt="image" src="https://github.com/user-attachments/assets/0aa21829-0fe3-4a4c-9d30-1c9e60cd8e02" />


