### PR TITLE
Henter flere uker når man kommer til slutten av lastet data

### DIFF
--- a/packages/frontend-v3/src/components/TimeTracker/HourInput.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/HourInput.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, watch } from "vue";
+import { ref, computed } from "vue";
 import { type TimeEntry } from "@/types/TimeEntryTypes";
 import { useTimeEntriesStore } from "@/stores/timeEntriesStore";
 import TrackRestOfDayButton from "./TrackRestOfDayButton.vue";
@@ -47,12 +47,6 @@ const { timeEntry, enableComments } = defineProps<{
 const comment = ref<string>(timeEntry.comment || "");
 
 const timeValue = ref<string>(timeEntry.value.toLocaleString("nb-NO"));
-
-watch(() => timeEntry.value, (newValue) => {
-	if (!isInputActive.value) {
-		timeValue.value = newValue.toLocaleString("nb-NO");
-	}
-});
 
 const weekend = computed(() => {
 	const day = new Date(timeEntry.date).getDay();

--- a/packages/frontend-v3/src/components/TimeTracker/HourInput.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/HourInput.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import { type TimeEntry } from "@/types/TimeEntryTypes";
 import { useTimeEntriesStore } from "@/stores/timeEntriesStore";
 import TrackRestOfDayButton from "./TrackRestOfDayButton.vue";
@@ -47,6 +47,12 @@ const { timeEntry, enableComments } = defineProps<{
 const comment = ref<string>(timeEntry.comment || "");
 
 const timeValue = ref<string>(timeEntry.value.toLocaleString("nb-NO"));
+
+watch(() => timeEntry.value, (newValue) => {
+	if (!isInputActive.value) {
+		timeValue.value = newValue.toLocaleString("nb-NO");
+	}
+});
 
 const weekend = computed(() => {
 	const day = new Date(timeEntry.date).getDay();

--- a/packages/frontend-v3/src/components/TimeTracker/TaskWeek.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/TaskWeek.vue
@@ -2,7 +2,7 @@
 	<div class="task-week">
 		<HourInput
 			v-for="timeEntry in filteredTimeEntriesForTask"
-			:key="`${timeEntry.taskId}-${timeEntry.date}`"
+			:key="`${timeEntry.taskId}-${timeEntry.date}-${timeEntry.id}`"
 			:timeEntry="timeEntry"
 			:enableComments="task.enableComments"
 		/>

--- a/packages/frontend-v3/src/components/TimeTracker/TimeTracker.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/TimeTracker.vue
@@ -20,7 +20,8 @@
 				<AlvtimeButton
 					id="prev-button"
 					iconLeft
-					@click="prevSlide"
+					@click="handlePrevClick"
+          :disabled="backwardSlideDisabled"
 				>
 					<FeatherIcon name="chevron-left" /> Tilbake
 				</AlvtimeButton>
@@ -32,7 +33,7 @@
 				<AlvtimeButton
 					id="next-button"
 					iconRight
-					@click="nextSlide"
+					@click="handleNextClick"
 				>
 					Fremover <FeatherIcon name="chevron-right" />
 				</AlvtimeButton>
@@ -125,6 +126,10 @@ const getWeekNumberString = (date: Date) => {
 	}
 };
 
+const backwardSlideDisabled = computed(() => {
+  return currentSlideIndex.value === 0;
+})
+
 const currentSlideIndex = computed(() => {
 	if (swiper.value) {
 		dateStore.setActiveWeekIndex(swiper.value.activeIndex);
@@ -174,22 +179,25 @@ const sortProjects = () => {
 	editingProjectOrder.value = true;
 };
 
-const nextSlide = () => {
-	if (swiper.value) {
-		swiper.value?.slideNext();
-	}
+const handleNextClick = async () => {
+  if (swiper.value) {
+    if (currentSlideIndex.value === dateStore.weeks.length - 1) {
+      await dateStore.extendWeeks();
+    }
+    swiper.value?.slideNext();
+  }
 };
 
-const prevSlide = () => {
-	if (swiper.value) {
-		swiper.value?.slidePrev();
-	}
+const handlePrevClick = async () => {
+  if (swiper.value) {
+    swiper.value?.slidePrev();
+  }
 };
 
 const goToCurrentWeek = () => {
-	if (swiper.value) {
-		swiper.value.slideTo(getInitialWeekSlide());
-	}
+  if (swiper.value) {
+    swiper.value.slideTo(getInitialWeekSlide());
+  }
 };
 
 onMounted(() => {

--- a/packages/frontend-v3/src/components/TimeTracker/TimeTracker.vue
+++ b/packages/frontend-v3/src/components/TimeTracker/TimeTracker.vue
@@ -21,7 +21,6 @@
 					id="prev-button"
 					iconLeft
 					@click="handlePrevClick"
-          :disabled="backwardSlideDisabled"
 				>
 					<FeatherIcon name="chevron-left" /> Tilbake
 				</AlvtimeButton>
@@ -93,7 +92,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, computed } from "vue";
+import { onMounted, ref, computed, nextTick } from "vue";
 import ProjectExpandable from "./ProjectExpandable.vue";
 import { useTaskStore } from "@/stores/taskStore";
 import { useDateStore } from "@/stores/dateStore";
@@ -125,10 +124,6 @@ const getWeekNumberString = (date: Date) => {
 		return `Uke ${getWeekNumber(date)}`;
 	}
 };
-
-const backwardSlideDisabled = computed(() => {
-  return currentSlideIndex.value === 0;
-})
 
 const currentSlideIndex = computed(() => {
 	if (swiper.value) {
@@ -180,24 +175,36 @@ const sortProjects = () => {
 };
 
 const handleNextClick = async () => {
-  if (swiper.value) {
-    if (currentSlideIndex.value === dateStore.weeks.length - 1) {
-      await dateStore.extendWeeks();
-    }
-    swiper.value?.slideNext();
-  }
+	if (swiper.value) {
+		if (currentSlideIndex.value === dateStore.weeks.length - 1) {
+			await dateStore.extendWeeks();
+		}
+		swiper.value?.slideNext();
+	}
 };
 
 const handlePrevClick = async () => {
-  if (swiper.value) {
-    swiper.value?.slidePrev();
-  }
+	if (swiper.value) {
+		if (currentSlideIndex.value === 0) {
+			const addedWeeksCount = await dateStore.prependWeeks();
+			await nextTick();
+			swiper.value.slideTo(addedWeeksCount - 1);
+		} else {
+			swiper.value.slidePrev();
+		}
+	}
 };
 
 const goToCurrentWeek = () => {
-  if (swiper.value) {
-    swiper.value.slideTo(getInitialWeekSlide());
-  }
+	if (swiper.value) {
+		const today = new Date();
+		today.setHours(0, 0, 0, 0);
+		const todayTime = today.getTime();
+		const index = dateStore.weeks.findIndex(week =>
+			week.some(day => day.getTime() === todayTime)
+		);
+		swiper.value.slideTo(index !== -1 ? index : getInitialWeekSlide());
+	}
 };
 
 onMounted(() => {

--- a/packages/frontend-v3/src/components/utils/AlvtimeButton.vue
+++ b/packages/frontend-v3/src/components/utils/AlvtimeButton.vue
@@ -55,5 +55,12 @@ button {
 		background-color: $secondary-color-light;
 		color: $primary-color;
 	}
+
+  &.disabled,
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 }
 </style>

--- a/packages/frontend-v3/src/stores/dateStore.ts
+++ b/packages/frontend-v3/src/stores/dateStore.ts
@@ -53,6 +53,32 @@ export const useDateStore = defineStore("date", () => {
 		return weeks.value[activeWeekIndex.value] || [];
 	});
 
+	const prependWeeks = async (): Promise<number> => {
+		const radius = getRadiusOfWeeks();
+		const newWeeks: Date[][] = [];
+		const firstDay = weeks.value[0][0];
+
+		for (let i = radius; i >= 1; i--) {
+			const date = new Date(firstDay);
+			date.setDate(firstDay.getDate() - i * 7);
+			newWeeks.push(createWeek(date));
+		}
+
+		weeks.value = [...newWeeks, ...weeks.value];
+
+		const years = getYearsInRange(
+			weeks.value[0][0].getFullYear(),
+			weeks.value[weeks.value.length - 1][6].getFullYear()
+		);
+		holidays.value = createNorwegianHolidays(years);
+
+		if (weeksDateRange.value) {
+			await timeEntriesStore.getTimeEntries(weeksDateRange.value);
+		}
+
+		return newWeeks.length;
+	};
+
 	const extendWeeks = async (): Promise<number> => {
 		const radius = getRadiusOfWeeks();
 		const newWeeks: Date[][] = [];
@@ -63,7 +89,7 @@ export const useDateStore = defineStore("date", () => {
 		for (let i = 1; i <= radius; i++) {
 			const date = new Date(lastDay);
 			date.setDate(lastDay.getDate() + i * 7);
-			newWeeks.push(createWeek(date))
+			newWeeks.push(createWeek(date));
 		}
 
 		weeks.value = [...weeks.value, ...newWeeks];
@@ -76,7 +102,7 @@ export const useDateStore = defineStore("date", () => {
 		}
 
 		return newWeeks.length;
-	}
+	};
 
 	const getYearsInRange = (start: number, end: number): number[] => {
 		const years: number[] = [];
@@ -94,6 +120,7 @@ export const useDateStore = defineStore("date", () => {
 		setActiveDate,
 		setActiveWeekIndex,
 		setSwiper,
-		extendWeeks
+		extendWeeks,
+		prependWeeks
 	};
 });

--- a/packages/frontend-v3/src/utils/weekHelper.ts
+++ b/packages/frontend-v3/src/utils/weekHelper.ts
@@ -92,10 +92,15 @@ const getInitialWeekSlide = () => {
 	return RADIUS_OF_WEEKS;
 };
 
+const getRadiusOfWeeks = () => {
+	return RADIUS_OF_WEEKS;
+};
+
 export {
 	getFirstDayOfWeek,
 	getWeekNumber,
 	createWeek,
 	createWeeks,
-	getInitialWeekSlide
+	getInitialWeekSlide,
+	getRadiusOfWeeks
 };

--- a/packages/frontend-v3/src/utils/weekHelper.ts
+++ b/packages/frontend-v3/src/utils/weekHelper.ts
@@ -1,5 +1,5 @@
 import { createNorwegianHolidays, type NorwegianHolidays } from "@/utils/holidayHelper";
-const RADIUS_OF_WEEKS = 52;
+const RADIUS_OF_WEEKS = 8;
 //const RADIUS_OF_DAYS = 7 * RADIUS_OF_WEEKS;
 
 const getFirstDayOfWeek = (date: Date, weekStartsOn: number = 1): Date => {


### PR DESCRIPTION
Når man kommer til slutten av lastet data (26 uker), hentes nye 26 uker med tilhørende timer og beregner nye helligdager. Det hentes ikke nye uker når man scroller bakover i tid da dette sannsynligvis ikke er et case man har bruk for.

OBS! Må testes: scroll forbi initiell maksdato (> 6 mnd), før en time på en dato mer enn 6 mnd fra i dag. Deretter refresh siden og scroll frem til datoen du førte på. Sjekk at timeføringen faktisk vises.

Closes #1119 