### PR TITLE
Using IMemoryCache instead of OutputCache

### DIFF
--- a/packages/api/AlvTime.Business/Absence/AbsenceDaysService.cs
+++ b/packages/api/AlvTime.Business/Absence/AbsenceDaysService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using AlvTime.Business.Options;
 using AlvTime.Business.TimeRegistration;
 using AlvTime.Business.Users;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
 namespace AlvTime.Business.Absence;
@@ -16,6 +17,7 @@ public class AbsenceDaysService : IAbsenceDaysService
     private readonly IUserContext _userContext;
     private readonly IAbsenceStorage _absenceStorage;
     private readonly IUserRepository _userStorage;
+    private readonly IMemoryCache _cache;
     private const int DefaultVacationDaysAmount = 25;
 
     // Current law says that you can take three 
@@ -24,13 +26,15 @@ public class AbsenceDaysService : IAbsenceDaysService
     private const int SickLeaveGroupSize = 3;
 
     public AbsenceDaysService(ITimeRegistrationStorage timeRegistrationStorage,
-        IOptionsMonitor<TimeEntryOptions> timeEntryOptions, IUserContext userContext, IAbsenceStorage absenceStorage, IUserRepository userStorage)
+        IOptionsMonitor<TimeEntryOptions> timeEntryOptions, IUserContext userContext, IAbsenceStorage absenceStorage,
+        IUserRepository userStorage, IMemoryCache cache)
     {
         _timeRegistrationStorage = timeRegistrationStorage;
         _timeEntryOptions = timeEntryOptions;
         _userContext = userContext;
         _absenceStorage = absenceStorage;
         _userStorage = userStorage;
+        _cache = cache;
     }
 
     public async Task<AbsenceDaysDto> GetAbsenceDays(int userId, DateTime? intervalStart)
@@ -115,7 +119,7 @@ public class AbsenceDaysService : IAbsenceDaysService
         var currentUser = await _userContext.GetCurrentUser();
         return await GetVacationOverviewForUser(currentUser.Id, currentUser.StartDate, currentYear);
     }
-    
+
     public async Task<VacationOverviewReport> GetAllTimeVacationOverviewForSingleUser(int currentYear, int userId)
     {
         var user = await _userStorage.GetUsers(new UserQuerySearch
@@ -127,24 +131,28 @@ public class AbsenceDaysService : IAbsenceDaysService
         {
             return null;
         }
-        
+
         var overview = await GetVacationOverviewForUser(userId, user.First().StartDate.Value, currentYear);
         return new VacationOverviewReport { UserId = userId, VacationDaysDto = overview };
     }
-    
+
     public async Task<List<VacationOverviewReport>> GetVacationOverviewForAllUsers(int currentYear)
     {
-        var users = await _userStorage.GetUsers(new UserQuerySearch());
-        var overridenVacationByUser = (await _absenceStorage.GetAllCustomVacationEarned()).ToLookup(v => v.UserId);
-        var reports = new List<VacationOverviewReport>();
-        foreach (var user in users.Where(u => u.StartDate.HasValue))
+        return await _cache.GetOrCreateAsync($"vacationReports_{currentYear}", async entry =>
         {
-            var dto = await GetVacationOverviewForUser(user.Id, user.StartDate!.Value, currentYear,
-                overridenVacationByUser[user.Id]);
-            reports.Add(new VacationOverviewReport { UserId = user.Id, VacationDaysDto = dto });
-        }
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+            var users = await _userStorage.GetUsers(new UserQuerySearch());
+            var overridenVacationByUser = (await _absenceStorage.GetAllCustomVacationEarned()).ToLookup(v => v.UserId);
+            var reports = new List<VacationOverviewReport>();
+            foreach (var user in users.Where(u => u.StartDate.HasValue))
+            {
+                var dto = await GetVacationOverviewForUser(user.Id, user.StartDate!.Value, currentYear,
+                    overridenVacationByUser[user.Id]);
+                reports.Add(new VacationOverviewReport { UserId = user.Id, VacationDaysDto = dto });
+            }
 
-        return reports;
+            return reports;
+        });
     }
 
     private async Task<VacationDaysDto> GetVacationOverviewForUser(int userId, DateTime userStartDate, int currentYear,
@@ -157,7 +165,7 @@ public class AbsenceDaysService : IAbsenceDaysService
             UserId = userId,
             TaskId = _timeEntryOptions.CurrentValue.PaidHolidayTask
         })).ToList();
-        
+
         var numberOfYearsWorked = currentYear - userStartDate.Year;
         var yearsWorked = new List<int>();
         var allRedDays = new HashSet<DateTime>();
@@ -197,10 +205,11 @@ public class AbsenceDaysService : IAbsenceDaysService
 
         var userStartDay = userStartDate.DayOfYear;
 
-        var overridenVacation = (overridenVacationEarned ?? await _absenceStorage.GetCustomVacationEarned(userId)).ToList();
+        var overridenVacation =
+            (overridenVacationEarned ?? await _absenceStorage.GetCustomVacationEarned(userId)).ToList();
 
         var unusedDaysTransferredFromLastYear = 0M;
-        
+
         foreach (var year in yearsWorked)
         {
             var daysLastYear = 365.2425M;
@@ -209,7 +218,7 @@ public class AbsenceDaysService : IAbsenceDaysService
             {
                 daysLastYear = 366.2425M;
             }
-            
+
             var daysEmployedLastYear = userStartDate.Year == year ? 0 :
                 userStartDate.Year == year - 1 ? daysLastYear - userStartDay : daysLastYear;
 

--- a/packages/api/AlvTime.Business/AlvTime.Business.csproj
+++ b/packages/api/AlvTime.Business/AlvTime.Business.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="10.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
   </ItemGroup>
 

--- a/packages/api/AlvTimeWebApi/Controllers/Admin/UserController.cs
+++ b/packages/api/AlvTimeWebApi/Controllers/Admin/UserController.cs
@@ -1,7 +1,7 @@
-﻿using AlvTime.Business.Users;
+﻿using System;
+using AlvTime.Business.Users;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using AlvTimeWebApi.Controllers.Utils;
 using AlvTimeWebApi.Requests;
@@ -10,32 +10,33 @@ using AlvTimeWebApi.Responses.Admin;
 using AlvTimeWebApi.ErrorHandling;
 using AlvTimeWebApi.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace AlvTimeWebApi.Controllers.Admin;
 
 [Route("api/admin")]
 [ApiController]
 [Authorize(Policy = "AdminPolicy")]
-public class UserController(UserService userService, GraphService graphService, IOutputCacheStore outputCacheStore) : ControllerBase
+public class UserController(UserService userService, GraphService graphService, IMemoryCache cache) : ControllerBase
 {
     [HttpGet("Users")]
-    [OutputCache(PolicyName = "Expire5Min", Tags = ["users"])]
-    public async Task<ActionResult<IEnumerable<UserAdminResponse>>> FetchUsers()
+    public async Task<ActionResult<List<UserAdminResponse>>> FetchUsers()
     {
-        var result = await userService.GetUsers(new UserQuerySearch());
-
-        if (!result.IsSuccess) return BadRequest(result.Errors.ToValidationProblemDetails("Hent brukere feilet"));
+        if (cache.TryGetValue("users", out List<UserAdminResponse> userResponses)) return Ok(userResponses);
         
-        var userResponses = new List<UserAdminResponse>();
-        var users = result.Value;
+        var result = await userService.GetUsers(new UserQuerySearch());
+        if (!result.IsSuccess)
+            return BadRequest(result.Errors.ToValidationProblemDetails("Hent brukere feilet"));
 
-        foreach (var user in users)
+        userResponses = [];
+        foreach (var user in result.Value)
         {
             var response = user.MapToUserResponse();
             response.ProfilePicture = await graphService.GetProfilePictureBase64(user.Oid, user.Email);
             userResponses.Add(response);
         }
+
+        cache.Set("users", userResponses, TimeSpan.FromMinutes(15));
 
         return Ok(userResponses);
     }
@@ -45,7 +46,7 @@ public class UserController(UserService userService, GraphService graphService, 
     {
         var userObjectId = await graphService.GetObjectIdByEmail(userToBeCreated.Email);
         var result = await userService.CreateUser(userToBeCreated.MapToUserDto(userObjectId));
-        await outputCacheStore.EvictByTagAsync("users", CancellationToken.None);
+        cache.Remove("users");
         return result.Match<ActionResult<UserAdminResponse>>(
             user => user.MapToUserResponse(),
             errors => BadRequest(errors.ToValidationProblemDetails("Opprettelse av bruker feilet")));
@@ -66,7 +67,7 @@ public class UserController(UserService userService, GraphService graphService, 
     public async Task<ActionResult<UserAdminResponse>> UpdateUser([FromBody] UserUpsertRequest userToBeUpdated, int userId)
     {
         var updatedUser = await userService.UpdateUser(userToBeUpdated.MapToUserDto(userId, "NA"));
-        await outputCacheStore.EvictByTagAsync("users", CancellationToken.None);
+        cache.Remove("users");
         return updatedUser.Match<ActionResult>(
             user => Ok(user.MapToUserResponse()),
             errors => BadRequest(errors.ToValidationProblemDetails("Oppdatering av bruker feilet")));

--- a/packages/api/AlvTimeWebApi/Controllers/Admin/VacationController.cs
+++ b/packages/api/AlvTimeWebApi/Controllers/Admin/VacationController.cs
@@ -4,14 +4,12 @@ using System.Threading.Tasks;
 using AlvTime.Business.Absence;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.OutputCaching;
 
 namespace AlvTimeWebApi.Controllers.Admin;
 
 [ApiController]
 [Route("api/admin")]
 [Authorize(Roles = "Admin")]
-[OutputCache(PolicyName = "Expire5Min")]
 public class VacationController(IAbsenceDaysService absenceDaysService) : ControllerBase
 {
     [HttpGet("vacationOverview")]

--- a/packages/api/AlvTimeWebApi/Startup.cs
+++ b/packages/api/AlvTimeWebApi/Startup.cs
@@ -54,10 +54,7 @@ public class Startup
         services.AddRazorPages();
         services.AddAlvtimeCorsPolicys(Configuration);
         services.ConfigureLogging(_environment);
-        services.AddOutputCache(options =>
-        {
-            options.AddPolicy("Expire5Min", builder => builder.Expire(TimeSpan.FromMinutes(5)));
-        });
+        services.AddMemoryCache();
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -86,7 +83,6 @@ public class Startup
             app.UseHttpsRedirection();
         }
 
-        app.UseOutputCache();
         app.UseCsrfMiddleware();
         app.UseAuthentication();
         app.UseAuthorization();

--- a/packages/api/Tests/UnitTests/AbsenceDaysService/AbsenceDayServiceTests.cs
+++ b/packages/api/Tests/UnitTests/AbsenceDaysService/AbsenceDayServiceTests.cs
@@ -5,6 +5,7 @@ using AlvTime.Business.TimeRegistration;
 using AlvTime.Business.Users;
 using AlvTime.Persistence.DatabaseModels;
 using AlvTime.Persistence.Repositories;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -562,6 +563,6 @@ public class AbsenceDayStorageTests
 
     private AlvTime.Business.Absence.AbsenceDaysService CreateAbsenceDaysService(TimeRegistrationStorage storage)
     {
-        return new AlvTime.Business.Absence.AbsenceDaysService(storage, _options, _userContextMock.Object, new AbsenceStorage(_context), new UserRepository(_context));
+        return new AlvTime.Business.Absence.AbsenceDaysService(storage, _options, _userContextMock.Object, new AbsenceStorage(_context), new UserRepository(_context), new MemoryCache(new MemoryCacheOptions()));
     }
 }


### PR DESCRIPTION
OutputCache vil ikke cache autentiserte requests eller requests som setter cookies, noe som passer dårlig med cookie-basert autentiseringsflyt. Bruker manuelt implementert IMemoryCache istedet.