### PR TITLE
cli: Fix API client accepting new timebank entry type

### DIFF
--- a/packages/cli/src/alvtime_cli/model.py
+++ b/packages/cli/src/alvtime_cli/model.py
@@ -71,6 +71,7 @@ class TimebankEntryType(IntEnum):
     OVERTIME = 0
     PAYOUT = 1
     FLEX = 2
+    FISCAL_YEAR_DEBT = 3
 
 
 class AvailableHoursEntry(BaseModel):


### PR DESCRIPTION
With the new salary model, the timebank entry type can now also be 3, FISCAL_YEAR_DEBT.